### PR TITLE
Add product discovery script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and fill in your SerpAPI key
+SERPAPI_API_KEY=your_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Ignore environment variables file
+.env
+
+# Python cache
+__pycache__/
+
+# CSV output
+/data/product_results.csv

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# AmazonFBA_AI_Agent
+# AmazonFBA AI Agent
+
+This repository contains a simple script to discover potential Amazon FBA product opportunities using [SerpAPI](https://serpapi.com/).
+
+## Setup
+1. Install dependencies:
+   ```bash
+   pip install python-dotenv serpapi
+   ```
+2. Copy `.env.example` to `.env` and add your SerpAPI API key:
+   ```bash
+   cp .env.example .env
+   # edit .env and set SERPAPI_API_KEY
+   ```
+
+## Usage
+Run the discovery script and enter your maximum unit price when prompted:
+
+```bash
+python product_discovery.py
+```
+
+The script searches several product categories and saves up to 20 results in `data/product_results.csv`.

--- a/product_discovery.py
+++ b/product_discovery.py
@@ -1,0 +1,97 @@
+import os
+import csv
+import re
+from typing import List, Dict
+
+from dotenv import load_dotenv
+from serpapi import GoogleSearch
+
+# Load SERPAPI_API_KEY from .env
+load_dotenv()
+API_KEY = os.getenv("SERPAPI_API_KEY")
+if not API_KEY:
+    raise EnvironmentError("SERPAPI_API_KEY not set in environment")
+
+# Predefined product keywords/categories
+KEYWORDS = ["kitchen", "fitness", "pets", "baby", "office", "gadgets"]
+
+MAX_RESULTS = 20
+DATA_PATH = os.path.join("data", "product_results.csv")
+
+
+def parse_price(value: str) -> float:
+    """Extract float price from a string like '$12.34'."""
+    if value is None:
+        return None
+    numbers = re.findall(r"\d+\.\d+|\d+", value)
+    if not numbers:
+        return None
+    return float(numbers[0])
+
+
+def search_products(keyword: str) -> List[Dict]:
+    """Search Google Shopping for the given keyword and return item list."""
+    params = {
+        "engine": "google_shopping",
+        "q": keyword,
+        "api_key": API_KEY,
+        "hl": "en",
+        "gl": "us",
+    }
+    search = GoogleSearch(params)
+    results = search.get_dict()
+    return results.get("shopping_results", []) or []
+
+
+def discover_products(budget: float) -> List[Dict]:
+    found = []
+    for keyword in KEYWORDS:
+        items = search_products(keyword)
+        count = 0
+        for item in items:
+            price = item.get("extracted_price")
+            if price is None:
+                price = parse_price(item.get("price"))
+            if price is None or price > budget:
+                continue
+            found.append({
+                "category": keyword,
+                "title": item.get("title"),
+                "price": price,
+                "product_id": item.get("product_id") or item.get("asin"),
+                "link": item.get("link"),
+            })
+            count += 1
+            if len(found) >= MAX_RESULTS:
+                return found
+        print(f"{keyword}: {count} valid products found")
+    return found
+
+
+def save_to_csv(products: List[Dict]):
+    os.makedirs(os.path.dirname(DATA_PATH), exist_ok=True)
+    with open(DATA_PATH, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=["category", "title", "price", "product_id", "link"],
+        )
+        writer.writeheader()
+        for item in products:
+            writer.writerow(item)
+
+
+def main():
+    try:
+        budget = float(input("Enter your maximum unit price in USD: "))
+    except ValueError:
+        print("Invalid budget")
+        return
+
+    products = discover_products(budget)
+    products.sort(key=lambda x: x["price"])  # sort by price ascending
+    save_to_csv(products)
+    print(f"Saved {len(products)} products to {DATA_PATH}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script to search Google Shopping via SerpAPI and save products under a budget
- ignore `.env` and output CSV files
- provide example `.env` template for SerpAPI key
- document usage instructions

## Testing
- `python -m py_compile product_discovery.py`

------
https://chatgpt.com/codex/tasks/task_e_6849469a9c6c83269dfc1fbdd343a28e