### PR TITLE
Refactor product discovery for budget-based workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ This repository contains a simple script to discover potential Amazon FBA produc
    ```
 
 ## Usage
-Run the discovery script and enter your maximum unit price when prompted:
+Run the discovery script and enter your total startup budget when prompted.
+The script reserves part of that budget for tools and subscriptions and uses the rest for product research:
 
 ```bash
 python product_discovery.py
 ```
 
-The script searches several product categories and saves up to 20 results in `data/product_results.csv`.
+The script searches several product categories, estimates profitability, and saves the top 10 opportunities in `data/product_results.csv`.
 
 ## Market Analysis
 To analyze the market potential of existing Amazon products by ASIN, run the
@@ -33,8 +34,9 @@ To analyze the market potential of existing Amazon products by ASIN, run the
 provide a CSV file containing an `asin` column via the `--csv` option. The
 script fetches pricing, rating, review count, and best seller rank using
 SerpAPI, assigns a simple score (HIGH/MEDIUM/LOW) based on rating and review
-count, then saves the results to `data/market_analysis_results.csv`. main
+count, then saves the results to `data/market_analysis_results.csv`.
 
 ```bash
 python market_analysis.py
 ```
+

--- a/product_discovery.py
+++ b/product_discovery.py
@@ -2,6 +2,7 @@ import os
 import csv
 import re
 from typing import List, Dict
+import random
 
 from dotenv import load_dotenv
 from serpapi import GoogleSearch
@@ -17,6 +18,15 @@ KEYWORDS = ["kitchen", "fitness", "pets", "baby", "office", "gadgets"]
 
 MAX_RESULTS = 20
 DATA_PATH = os.path.join("data", "product_results.csv")
+
+# Reserve this amount from the startup budget for tools/subscriptions
+FIXED_COST = 200.0
+
+# Cost multiplier range for estimating landed cost of goods
+COST_RANGE = (0.3, 0.7)
+
+# Portion of the sale price taken by FBA fees
+FBA_FEE_RATE = 0.3
 
 
 def parse_price(value: str) -> float:
@@ -43,54 +53,94 @@ def search_products(keyword: str) -> List[Dict]:
     return results.get("shopping_results", []) or []
 
 
-def discover_products(budget: float) -> List[Dict]:
+def discover_products(variable_budget: float) -> List[Dict]:
+    """Search for products and calculate potential margins."""
     found = []
     for keyword in KEYWORDS:
         items = search_products(keyword)
         count = 0
         for item in items:
-            price = item.get("extracted_price")
-            if price is None:
-                price = parse_price(item.get("price"))
-            if price is None or price > budget:
+            sale_price = item.get("extracted_price")
+            if sale_price is None:
+                sale_price = parse_price(item.get("price"))
+            if sale_price is None:
                 continue
+
+            cost_multiplier = random.uniform(*COST_RANGE)
+            unit_cost = sale_price * cost_multiplier
+            quantity = int(variable_budget // unit_cost)
+            if quantity <= 0:
+                continue
+            profit_per_unit = sale_price * (1 - FBA_FEE_RATE) - unit_cost
+            total_margin = profit_per_unit * quantity
+
             found.append({
                 "category": keyword,
                 "title": item.get("title"),
-                "price": price,
+                "sale_price": sale_price,
+                "unit_cost": unit_cost,
+                "quantity": quantity,
+                "total_margin": total_margin,
                 "product_id": item.get("product_id") or item.get("asin"),
                 "link": item.get("link"),
             })
             count += 1
             if len(found) >= MAX_RESULTS:
                 return found
-        print(f"{keyword}: {count} valid products found")
+        print(f"{keyword}: {count} opportunities found")
     return found
 
 
 def save_to_csv(products: List[Dict]):
+    """Save ranked product results to CSV."""
     os.makedirs(os.path.dirname(DATA_PATH), exist_ok=True)
     with open(DATA_PATH, "w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(
             f,
-            fieldnames=["category", "title", "price", "product_id", "link"],
+            fieldnames=[
+                "category",
+                "title",
+                "sale_price",
+                "unit_cost",
+                "quantity",
+                "total_margin",
+                "product_id",
+                "link",
+            ],
         )
         writer.writeheader()
         for item in products:
             writer.writerow(item)
 
 
+def print_report(products: List[Dict]):
+    for p in products:
+        print(f"Category: {p['category']}")
+        print(f"Title: {p['title']}")
+        print(f"Sale Price: ${p['sale_price']:.2f}")
+        print(f"Est. Unit Cost: ${p['unit_cost']:.2f}")
+        print(f"Quantity Purchasable: {p['quantity']}")
+        print(f"Expected Total Margin: ${p['total_margin']:.2f}\n")
+
+
 def main():
     try:
-        budget = float(input("Enter your maximum unit price in USD: "))
+        budget = float(input("Enter your total startup budget in USD: "))
     except ValueError:
         print("Invalid budget")
         return
 
-    products = discover_products(budget)
-    products.sort(key=lambda x: x["price"])  # sort by price ascending
-    save_to_csv(products)
-    print(f"Saved {len(products)} products to {DATA_PATH}")
+    variable_budget = budget - FIXED_COST
+    if variable_budget <= 0:
+        print("Budget is too low after reserving fixed costs")
+        return
+
+    products = discover_products(variable_budget)
+    products.sort(key=lambda x: x["total_margin"], reverse=True)
+    top_products = products[:10]
+    print_report(top_products)
+    save_to_csv(top_products)
+    print(f"Saved {len(top_products)} products to {DATA_PATH}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- refactor `product_discovery.py` to use a startup budget
- estimate unit cost, quantity, and margin per product
- rank results by total expected margin
- print a summary report and save the top 10 to CSV
- document new workflow in the README

## Testing
- `python -m py_compile product_discovery.py`
- `python -m py_compile market_analysis.py`


------
https://chatgpt.com/codex/tasks/task_e_6849a1854bd88326956902a03a1a2000