### PR TITLE
Fix SerpAPI search parameter

### DIFF
--- a/product_discovery.py
+++ b/product_discovery.py
@@ -43,7 +43,8 @@ def search_category(category: str) -> List[Dict]:
     params = {
         "engine": "amazon",
         "type": "search",
-        "keyword": category,
+        # "k" is the search query parameter for Amazon results
+        "k": category,
         "amazon_domain": "amazon.com",
         "gl": "us",
         "hl": "en",


### PR DESCRIPTION
## Summary
- use `k` as the query parameter for Amazon search
- add comment clarifying SerpAPI request

## Testing
- `python -m py_compile product_discovery.py market_analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_6849c0466adc8326ba8d24b4fee8bcb5