### PR TITLE
Implement title-based fallback in market analysis

### DIFF
--- a/market_analysis.py
+++ b/market_analysis.py
@@ -3,7 +3,7 @@ import csv
 import re
 import argparse
 import time
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Tuple
 
 from dotenv import load_dotenv
 from serpapi import GoogleSearch
@@ -91,23 +91,103 @@ def fetch_product_info(asin: str) -> Optional[Dict[str, str]]:
     }
 
 
-def process_asins(asins: List[str]) -> List[Dict[str, str]]:
+def fetch_product_by_title(title: str) -> Optional[Dict[str, str]]:
+    """Search Amazon by title and return info from the most relevant result."""
+    params = {
+        "engine": "amazon",
+        "api_key": API_KEY,
+        "amazon_domain": "amazon.com",
+        "type": "search",
+        "search_term": title,
+    }
+    try:
+        search = GoogleSearch(params)
+        result = search.get_dict()
+    except Exception as exc:
+        print(f"Error searching for '{title}': {exc}")
+        return None
+
+    items = result.get("organic_results", []) or []
+    if not items:
+        print(f"No search results for '{title}'")
+        return None
+
+    # Pick item with position==1, otherwise highest rating * reviews
+    best = None
+    best_score = -1.0
+    for item in items:
+        if item.get("position") == 1:
+            best = item
+            break
+        rating = parse_float(str(item.get("rating"))) or 0
+        reviews = parse_float(str(item.get("reviews"))) or 0
+        score = rating * reviews
+        if score > best_score:
+            best_score = score
+            best = item
+
+    if not best:
+        return None
+
+    asin = best.get("asin")
+    link = best.get("link") or best.get("url")
+    if not asin and link:
+        m = re.search(r"/dp/([A-Z0-9]{10})", link)
+        asin = m.group(1) if m else None
+
+    price = parse_float(
+        best.get("price", {}).get("raw") if isinstance(best.get("price"), dict) else best.get("price")
+    )
+    rating = parse_float(str(best.get("rating")))
+    reviews = parse_float(str(best.get("reviews")))
+
+    bsr = None
+    if asin and is_valid_asin(asin):
+        detail = fetch_product_info(asin)
+        if detail:
+            bsr = detail.get("bsr")
+
+    return {
+        "asin": asin,
+        "title": best.get("title"),
+        "price": price,
+        "rating": rating,
+        "reviews": reviews,
+        "bsr": bsr,
+        "link": link,
+    }
+
+
+def process_products(products: List[Dict[str, str]]) -> Tuple[List[Dict[str, str]], int, int, int]:
+    """Process a list of entries containing asin and optional title."""
     results = []
-    for asin in asins:
-        asin = asin.strip()
-        if not asin:
+    real = estimated = failed = 0
+    for item in products:
+        asin = (item.get("asin") or "").strip()
+        title = (item.get("title") or "").strip()
+
+        data = None
+        if is_valid_asin(asin):
+            data = fetch_product_info(asin)
+            if data:
+                data["estimated"] = False
+                real += 1
+        if not data and title:
+            data = fetch_product_by_title(title)
+            if data:
+                data["estimated"] = True
+                estimated += 1
+
+        if not data:
+            print(f"Failed to fetch data for entry: ASIN='{asin}' Title='{title[:40]}'")
+            failed += 1
             continue
-        if not is_valid_asin(asin):
-            print(f"Invalid ASIN {asin}, skipping")
-            continue
-        data = fetch_product_info(asin)
-        if data:
-            data["score"] = evaluate_potential(data)
-            results.append(data)
-        else:
-            print(f"Skipping ASIN {asin}")
+
+        data["score"] = evaluate_potential(data)
+        results.append(data)
         time.sleep(1)  # small delay for rate limits
-    return results
+
+    return results, real, estimated, failed
 
 
 def load_asins_from_csv(path: str) -> List[str]:
@@ -139,12 +219,44 @@ def load_asins_from_csv(path: str) -> List[str]:
     return asins
 
 
+def load_products_from_csv(path: str) -> List[Dict[str, str]]:
+    """Return list of entries with asin and title from a CSV file."""
+    products = []
+    try:
+        with open(path, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            if "asin" not in reader.fieldnames:
+                print(f"CSV {path} is missing an 'asin' column")
+                return []
+            for row in reader:
+                asin = (row.get("asin") or "").strip()
+                title = (row.get("title") or "").strip()
+                products.append({"asin": asin, "title": title})
+    except FileNotFoundError:
+        print(f"File not found: {path}")
+        return []
+    except Exception as exc:
+        print(f"Error reading {path}: {exc}")
+        return []
+    return products
+
+
 def save_to_csv(products: List[Dict[str, str]]):
     os.makedirs(os.path.dirname(DATA_PATH), exist_ok=True)
     with open(DATA_PATH, "w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(
             f,
-            fieldnames=["asin", "title", "price", "rating", "reviews", "bsr", "link", "score"],
+            fieldnames=[
+                "asin",
+                "title",
+                "price",
+                "rating",
+                "reviews",
+                "bsr",
+                "link",
+                "score",
+                "estimated",
+            ],
         )
         writer.writeheader()
         for item in products:
@@ -153,12 +265,12 @@ def save_to_csv(products: List[Dict[str, str]]):
 
 def print_report(products: List[Dict[str, str]]):
     for p in products:
-        print(f"ASIN: {p['asin']}")
+        print(f"ASIN: {p.get('asin')}")
         print(f"Title: {p.get('title')}")
         print(f"Price: {p.get('price')}")
         print(f"Rating: {p.get('rating')} ({p.get('reviews')} reviews)")
         print(f"BSR: {p.get('bsr')}")
-        print(f"Score: {p.get('score')}")
+        print(f"Score: {p.get('score')} (estimated: {p.get('estimated')})")
         print(f"Link: {p.get('link')}\n")
 
 
@@ -168,9 +280,9 @@ def main():
     args = parser.parse_args()
 
     if args.csv:
-        asins = load_asins_from_csv(args.csv)
-        if not asins:
-            print(f"No ASINs found in {args.csv}")
+        entries = load_products_from_csv(args.csv)
+        if not entries:
+            print(f"No products found in {args.csv}")
             return
     else:
         prompt = (
@@ -179,31 +291,37 @@ def main():
         )
         asin_input = input(prompt).strip()
         if asin_input:
-            asins = [a.strip() for a in asin_input.split(",") if a.strip()]
-            asins = [a for a in asins if is_valid_asin(a)]
-            if not asins:
+            entered = [a.strip() for a in asin_input.split(",") if a.strip()]
+            valid = [a for a in entered if is_valid_asin(a)]
+            if not valid:
                 print("No valid ASINs provided")
                 return
+            if len(valid) < len(entered):
+                print(f"Skipped {len(entered) - len(valid)} invalid ASIN(s)")
+            entries = [{"asin": a, "title": ""} for a in valid]
         else:
-            asins = load_asins_from_csv(DISCOVERY_CSV)
-            if not asins:
+            entries = load_products_from_csv(DISCOVERY_CSV)
+            if not entries:
                 print(
-                    f"Could not load ASINs from {DISCOVERY_CSV}. "
-                    "Ensure the file exists and has an 'asin' column."
+                    f"Could not load products from {DISCOVERY_CSV}. "
+                    "Ensure the file exists and has 'asin' and 'title' columns."
                 )
                 return
-            print(f"Loaded {len(asins)} ASINs from {DISCOVERY_CSV}")
+            print(f"Loaded {len(entries)} products from {DISCOVERY_CSV}")
 
-    if not asins:
-        print("No ASINs provided")
+    if not entries:
+        print("No products provided")
         return
-    products = process_asins(asins)
+    products, real, estimated, failed = process_products(entries)
     if not products:
         print("No product data retrieved")
         return
     print_report(products)
     save_to_csv(products)
     print(f"Saved {len(products)} results to {DATA_PATH}")
+    print(
+        f"Analyzed with ASIN data: {real} | Estimated by title: {estimated} | Failed: {failed}"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support fallback search via product title in `market_analysis.py`
- mark estimated results and display summary counts
- update CSV output to include new `estimated` field

## Testing
- `python -m py_compile market_analysis.py product_discovery.py`


------
https://chatgpt.com/codex/tasks/task_e_684a9d42f3b8832693e9440f30a5be5c