### PR TITLE
Improve ASIN handling and logging

### DIFF
--- a/product_discovery.py
+++ b/product_discovery.py
@@ -5,6 +5,7 @@ import argparse
 from math import floor
 from typing import List, Dict, Optional, Tuple
 from difflib import SequenceMatcher
+import time
 
 from dotenv import load_dotenv
 from serpapi import GoogleSearch
@@ -43,8 +44,37 @@ def extract_asin_from_url(url: str) -> Optional[str]:
     return m.group(1) if m else None
 
 
+ASIN_PATTERN = r"^B0[A-Z0-9]{8}$"
+
+
 def is_asin_format(asin: str) -> bool:
-    return bool(re.fullmatch(r"[A-Z0-9]{10}", asin or ""))
+    """Return True if asin matches Amazon's B0-prefixed pattern."""
+    return bool(re.fullmatch(ASIN_PATTERN, asin or ""))
+
+
+def search_similar_asin(title: str, verbose: bool = False) -> Optional[str]:
+    """Search Amazon for the given title and return first valid ASIN."""
+    params = {
+        "engine": "amazon",
+        "type": "search",
+        "amazon_domain": "amazon.com",
+        "k": title,
+        "api_key": API_KEY,
+    }
+    try:
+        search = GoogleSearch(params)
+        data = search.get_dict()
+    except Exception as exc:
+        if verbose:
+            print(f"Error estimating ASIN for '{title}': {exc}")
+        return None
+    for item in data.get("organic_results", []) or []:
+        asin = item.get("asin") or extract_asin_from_url(item.get("link") or item.get("url"))
+        if asin and is_asin_format(asin):
+            if verbose:
+                print(f"Estimated ASIN {asin} for '{title}'")
+            return asin
+    return None
 
 
 def log_skipped(reason: str, item: Dict):
@@ -93,13 +123,22 @@ def compute_metrics(price: float, budget: float) -> Tuple[float, float, int, flo
     return est_cost, margin, units, total_profit
 
 
-def discover_products(variable_budget: float, debug: bool = False) -> Tuple[List[Dict[str, object]], List[Dict[str, int]]]:
+def discover_products(
+    variable_budget: float,
+    debug: bool = False,
+    verbose: bool = False,
+    max_products: int = 0,
+) -> Tuple[List[Dict[str, object]], List[Dict[str, int]]]:
+    """Return discovered products and per-category summary."""
     results: List[Dict[str, object]] = []
     summary: List[Dict[str, int]] = []
+    seen: set = set()
+
     for cat in CATEGORIES:
         raw_items = search_category(cat, pages=3, debug=debug)
-        valid_items: List[Dict] = []
         valid = estimated = skipped = 0
+        count = 0
+
         for item in raw_items:
             if debug:
                 print("RAW", item)
@@ -108,64 +147,60 @@ def discover_products(variable_budget: float, debug: bool = False) -> Tuple[List
                 log_skipped("missing title", item)
                 skipped += 1
                 continue
+
             price = parse_price(item.get("price"))
             if price is None or price <= 0:
                 log_skipped("missing/invalid price", item)
                 skipped += 1
                 continue
+
             link = item.get("link") or item.get("url")
             asin = item.get("asin") or extract_asin_from_url(link)
-            rating = parse_float(item.get("rating"))
-            reviews = parse_float(item.get("reviews"))
-            if asin and is_asin_format(asin):
-                est_cost, margin, units, total_profit = compute_metrics(price, variable_budget)
-                if units <= 0:
-                    log_skipped("no units", item)
+            est_asin = None
+
+            if not (asin and is_asin_format(asin)):
+                asin = None
+                est_asin = search_similar_asin(title, verbose=verbose)
+                if not est_asin:
+                    log_skipped("no valid ASIN found", item)
                     skipped += 1
                     continue
-                entry = {
-                    "title": title,
-                    "asin": asin,
-                    "estimated": False,
-                    "price": price,
-                    "rating": rating,
-                    "reviews": reviews,
-                    "est_cost": est_cost,
-                    "margin": margin,
-                    "units_possible": units,
-                    "estimated_total_profit": total_profit,
-                    "link": link,
-                }
-                results.append(entry)
-                valid_items.append(entry)
+
+            chosen = asin or est_asin
+            if chosen in seen:
+                log_skipped("duplicate", item)
+                skipped += 1
+                continue
+
+            est_cost, margin, units, total_profit = compute_metrics(price, variable_budget)
+            if units <= 0:
+                log_skipped("no units", item)
+                skipped += 1
+                continue
+
+            entry = {
+                "title": title,
+                "asin": asin or "",
+                "estimated_asin": est_asin or "",
+                "price": price,
+                "margin": margin,
+                "units": units,
+                "total_profit": total_profit,
+            }
+
+            results.append(entry)
+            seen.add(chosen)
+            if asin:
                 valid += 1
             else:
-                match = similar_item(title, valid_items)
-                if not match:
-                    log_skipped("missing ASIN", item)
-                    skipped += 1
-                    continue
-                est_cost, margin, units, total_profit = compute_metrics(price, variable_budget)
-                if units <= 0:
-                    log_skipped("no units", item)
-                    skipped += 1
-                    continue
-                entry = {
-                    "title": title,
-                    "asin": match["asin"],
-                    "estimated": True,
-                    "price": price,
-                    "rating": match.get("rating"),
-                    "reviews": match.get("reviews"),
-                    "est_cost": est_cost,
-                    "margin": margin,
-                    "units_possible": units,
-                    "estimated_total_profit": total_profit,
-                    "link": link,
-                }
-                results.append(entry)
                 estimated += 1
+
+            count += 1
+            if max_products and count >= max_products:
+                break
+
         summary.append({"category": cat, "valid": valid, "estimated": estimated, "skipped": skipped})
+
     return results, summary
 
 
@@ -177,15 +212,11 @@ def save_to_csv(products: List[Dict[str, object]]):
             fieldnames=[
                 "title",
                 "asin",
-                "estimated",
+                "estimated_asin",
                 "price",
-                "rating",
-                "reviews",
-                "est_cost",
                 "margin",
-                "units_possible",
-                "estimated_total_profit",
-                "link",
+                "units",
+                "total_profit",
             ],
         )
         writer.writeheader()
@@ -203,14 +234,16 @@ def print_report(products: List[Dict[str, object]]):
             f"{title:40} | "
             f"${p['price']:>6.2f} | "
             f"${p['margin']:>6.2f} | "
-            f"{p['units_possible']:>5} | "
-            f"${p['estimated_total_profit']:>11.2f}"
+            f"{p['units']:>5} | "
+            f"${p['total_profit']:>11.2f}"
         )
 
 
 def main():
     parser = argparse.ArgumentParser(description="Discover Amazon products")
-    parser.add_argument("--debug", action="store_true", help="print raw entries")
+    parser.add_argument("--debug", action="store_true", help="print raw SerpAPI results")
+    parser.add_argument("--verbose", action="store_true", help="print verbose logs")
+    parser.add_argument("--max-products", type=int, default=0, help="limit products per category")
     args = parser.parse_args()
 
     try:
@@ -222,11 +255,16 @@ def main():
     if variable_budget <= 0:
         raise SystemExit("Budget too low after reserving fixed costs")
 
-    products, summary = discover_products(variable_budget, debug=args.debug)
+    products, summary = discover_products(
+        variable_budget,
+        debug=args.debug,
+        verbose=args.verbose,
+        max_products=args.max_products,
+    )
     if not products:
         raise SystemExit("No products found")
 
-    products.sort(key=lambda x: x["estimated_total_profit"], reverse=True)
+    products.sort(key=lambda x: x["total_profit"], reverse=True)
     top = products[:20]
 
     for s in summary:


### PR DESCRIPTION
## Summary
- validate ASINs with B0-prefixed pattern
- estimate missing ASINs via extra SerpAPI search
- add verbose logging and limit option in discovery
- store estimated ASINs in output CSV
- use estimated ASINs when analyzing products and record processing stats

## Testing
- `python -m py_compile product_discovery.py market_analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_684a9f4dffb8832680aa436cc8e1e3b9