### PR TITLE
Add Keepa fallback to market analysis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 # Copy this file to .env and fill in your SerpAPI key
 SERPAPI_API_KEY=your_api_key_here
+# Optional Keepa API key if you prefer to store it in the environment
+KEEPA_API_KEY=

--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ This repository contains a simple script to discover potential Amazon FBA produc
    ```bash
    pip uninstall serpapi
    ```
-2. Copy `.env.example` to `.env` and add your SerpAPI API key:
+2. Copy `.env.example` to `.env` and add your SerpAPI API key. Optionally copy
+   `config.example.json` to `config.json` to store both SerpAPI and Keepa keys:
    ```bash
    cp .env.example .env
    # edit .env and set SERPAPI_API_KEY
+   cp config.example.json config.json  # edit and set KEEPPA/SerpAPI keys
    ```
 
 ## Usage
@@ -35,9 +37,10 @@ To analyze the market potential of existing Amazon products by ASIN, run the
 provide a CSV file containing an `asin` column via the `--csv` option. If you
 press **Enter** without typing any ASINs, the script will automatically load the
 values from `data/product_results.csv` created by `product_discovery.py`. The
-script fetches pricing, rating, review count, and best seller rank using
-SerpAPI, assigns a simple score (HIGH/MEDIUM/LOW) based on rating and review
-count, then saves the results to `data/market_analysis_results.csv`.
+The script fetches pricing, rating, review count, and best seller rank. It uses
+SerpAPI as the primary source and falls back to Keepa when necessary. You can
+disable keyword-based fallback searches with the `--no-fallback` flag. Results
+are saved to `data/market_analysis_results.csv`.
 
 ```bash
 python market_analysis.py

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,4 @@
+{
+    "serpapi_key": "YOUR_SERPAPI_KEY",
+    "keepa_key": "YOUR_KEEPA_KEY"
+}


### PR DESCRIPTION
## Summary
- load SerpAPI and Keepa API keys from environment, config, or prompt
- integrate Keepa API as fallback in `market_analysis.py`
- add `--no-fallback` flag and log API source
- provide example config and update environment and README docs

## Testing
- `python -m py_compile market_analysis.py`
- `python -m py_compile product_discovery.py`

------
https://chatgpt.com/codex/tasks/task_e_684aa17ad4bc8326aa3a39b5d7987126