### PR TITLE
Improve manual mode for market analysis

### DIFF
--- a/data/mock_market_data.csv
+++ b/data/mock_market_data.csv
@@ -1,0 +1,3 @@
+asin,title,price,rating,reviews,bsr,link,source,estimated,score
+B0TESTASIN,Sample Product,19.99,4.5,250,1234,https://example.com/mock,Bulk,True,80
+B0TESTAS2,Another Product,29.99,4.2,120,2345,https://example.com/mock2,Bulk,True,75


### PR DESCRIPTION
## Summary
- support mock data via `data/mock_market_data.csv`
- add `MOCK_DATA_CSV` constant
- enhance manual mode detection and reporting
- print report and save CSV in both manual and API modes
- add sample mock data file

## Testing
- `python -m py_compile market_analysis.py product_discovery.py`
- `python market_analysis.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684abbe797708326bfc30938c75c91e4