### PR TITLE
Enable offline market analysis with mock data

### DIFF
--- a/data/mock_market_data.csv
+++ b/data/mock_market_data.csv
@@ -1,3 +1,4 @@
 asin,title,price,rating,reviews,bsr,link,source,estimated,score
 B0TESTASIN,Sample Product,19.99,4.5,250,1234,https://example.com/mock,Bulk,True,80
 B0TESTAS2,Another Product,29.99,4.2,120,2345,https://example.com/mock2,Bulk,True,75
+B0TESTAS3,Third Product,15.50,3.9,80,3456,https://example.com/mock3,Bulk,True,65

--- a/market_analysis.py
+++ b/market_analysis.py
@@ -387,33 +387,20 @@ def main():
             "Operating in partial mode - missing " + ", ".join(missing)
         )
     else:
-        print("Operating in manual/simulated mode - no API keys found")
+        print("No API keys detected. Entering MANUAL MODE using mock_market_data.csv")
 
     if mode == "MANUAL":
-        if args.csv:
-            products = load_manual_csv(args.csv)
-        else:
-            products = manual_input()
-            if not products:
-                print(f"No manual data entered. Trying '{MOCK_DATA_CSV}' ...")
-                products = load_manual_csv(MOCK_DATA_CSV)
-                if products:
-                    print(
-                        f"Loaded {len(products)} products from mock file."
-                    )
-                else:
-                    print(
-                        f"Warning: mock data file '{MOCK_DATA_CSV}' not found or empty"
-                    )
-                    return
+        csv_path = args.csv or MOCK_DATA_CSV
+        products = load_manual_csv(csv_path)
         if not products:
-            print("No product data available. Exiting.")
+            print("No valid data found in mock_market_data.csv. Exiting.")
             return
         for p in products:
             p["potential"] = evaluate_potential(p)
         print_report(products)
         save_to_csv(products)
-        print(f"Saved {len(products)} products to {DATA_PATH}")
+        print(f"{len(products)} products loaded from {csv_path}")
+        print("Manual analysis complete. Results saved to data/market_analysis_results.csv")
         return
 
     # API based modes


### PR DESCRIPTION
## Summary
- update `market_analysis.py` to automatically switch to manual mode when no API keys are available
- load `data/mock_market_data.csv` in that case and save the results
- provide sample mock data with a third sample product

## Testing
- `python -m py_compile market_analysis.py`
- `python market_analysis.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684abfa351c88326a9bf2ac9f8b0e7d3