### PR TITLE
Add generator for mock market data

### DIFF
--- a/data/mock_market_data.csv
+++ b/data/mock_market_data.csv
@@ -1,4 +1,11 @@
-asin,title,price,rating,reviews,bsr,link,source,estimated,score
-B0TESTASIN,Sample Product,19.99,4.5,250,1234,https://example.com/mock,Bulk,True,80
-B0TESTAS2,Another Product,29.99,4.2,120,2345,https://example.com/mock2,Bulk,True,75
-B0TESTAS3,Third Product,15.50,3.9,80,3456,https://example.com/mock3,Bulk,True,65
+asin,title,price,rating,reviews,bsr,link,source,score,estimated
+B0ABCDE001,Stainless Steel Mixing Bowl Set,25.99,4.7,820,350,https://example.com/B0ABCDE001,serpapi,HIGH,False
+B0ABCDE002,Non-Stick Frying Pan 12 Inch,32.5,4.6,560,450,https://example.com/B0ABCDE002,serpapi,HIGH,False
+B0ABCDE003,Adjustable Dumbbell Set 20lb,40.0,4.2,210,900,https://example.com/B0ABCDE003,keepa,MEDIUM,False
+B0ABCDE004,Yoga Mat Eco-Friendly 6mm,23.99,4.1,150,1200,https://example.com/B0ABCDE004,keepa,MEDIUM,False
+B0ABCDE005,Baby Swaddle Blanket,18.5,4.5,300,1400,https://example.com/B0ABCDE005,serpapi,HIGH,False
+B0ABCDE006,Portable Blender for Smoothies,29.99,3.8,90,1800,https://example.com/B0ABCDE006,manual,LOW,True
+B0ABCDE007,Cordless Handheld Vacuum,65.99,4.4,430,320,https://example.com/B0ABCDE007,manual,HIGH,True
+B0ABCDE008,Silicone Baking Mat 2 Pack,13.99,4.3,270,1000,https://example.com/B0ABCDE008,keepa,MEDIUM,False
+B0ABCDE009,Organic Cotton Baby Bibs Set,16.99,4.0,80,2000,https://example.com/B0ABCDE009,serpapi,MEDIUM,True
+B0ABCDE010,Electric Milk Frother Handheld,14.49,4.6,512,600,https://example.com/B0ABCDE010,manual,HIGH,False

--- a/generate_mock_market_data.py
+++ b/generate_mock_market_data.py
@@ -1,0 +1,153 @@
+import csv
+import os
+
+# Define mock market data
+mock_products = [
+    {
+        "asin": "B0ABCDE001",
+        "title": "Stainless Steel Mixing Bowl Set",
+        "price": 25.99,
+        "rating": 4.7,
+        "reviews": 820,
+        "bsr": 350,
+        "link": "https://example.com/B0ABCDE001",
+        "source": "serpapi",
+        "score": "HIGH",
+        "estimated": False,
+    },
+    {
+        "asin": "B0ABCDE002",
+        "title": "Non-Stick Frying Pan 12 Inch",
+        "price": 32.50,
+        "rating": 4.6,
+        "reviews": 560,
+        "bsr": 450,
+        "link": "https://example.com/B0ABCDE002",
+        "source": "serpapi",
+        "score": "HIGH",
+        "estimated": False,
+    },
+    {
+        "asin": "B0ABCDE003",
+        "title": "Adjustable Dumbbell Set 20lb",
+        "price": 40.0,
+        "rating": 4.2,
+        "reviews": 210,
+        "bsr": 900,
+        "link": "https://example.com/B0ABCDE003",
+        "source": "keepa",
+        "score": "MEDIUM",
+        "estimated": False,
+    },
+    {
+        "asin": "B0ABCDE004",
+        "title": "Yoga Mat Eco-Friendly 6mm",
+        "price": 23.99,
+        "rating": 4.1,
+        "reviews": 150,
+        "bsr": 1200,
+        "link": "https://example.com/B0ABCDE004",
+        "source": "keepa",
+        "score": "MEDIUM",
+        "estimated": False,
+    },
+    {
+        "asin": "B0ABCDE005",
+        "title": "Baby Swaddle Blanket",
+        "price": 18.50,
+        "rating": 4.5,
+        "reviews": 300,
+        "bsr": 1400,
+        "link": "https://example.com/B0ABCDE005",
+        "source": "serpapi",
+        "score": "HIGH",
+        "estimated": False,
+    },
+    {
+        "asin": "B0ABCDE006",
+        "title": "Portable Blender for Smoothies",
+        "price": 29.99,
+        "rating": 3.8,
+        "reviews": 90,
+        "bsr": 1800,
+        "link": "https://example.com/B0ABCDE006",
+        "source": "manual",
+        "score": "LOW",
+        "estimated": True,
+    },
+    {
+        "asin": "B0ABCDE007",
+        "title": "Cordless Handheld Vacuum",
+        "price": 65.99,
+        "rating": 4.4,
+        "reviews": 430,
+        "bsr": 320,
+        "link": "https://example.com/B0ABCDE007",
+        "source": "manual",
+        "score": "HIGH",
+        "estimated": True,
+    },
+    {
+        "asin": "B0ABCDE008",
+        "title": "Silicone Baking Mat 2 Pack",
+        "price": 13.99,
+        "rating": 4.3,
+        "reviews": 270,
+        "bsr": 1000,
+        "link": "https://example.com/B0ABCDE008",
+        "source": "keepa",
+        "score": "MEDIUM",
+        "estimated": False,
+    },
+    {
+        "asin": "B0ABCDE009",
+        "title": "Organic Cotton Baby Bibs Set",
+        "price": 16.99,
+        "rating": 4.0,
+        "reviews": 80,
+        "bsr": 2000,
+        "link": "https://example.com/B0ABCDE009",
+        "source": "serpapi",
+        "score": "MEDIUM",
+        "estimated": True,
+    },
+    {
+        "asin": "B0ABCDE010",
+        "title": "Electric Milk Frother Handheld",
+        "price": 14.49,
+        "rating": 4.6,
+        "reviews": 512,
+        "bsr": 600,
+        "link": "https://example.com/B0ABCDE010",
+        "source": "manual",
+        "score": "HIGH",
+        "estimated": False,
+    },
+]
+
+def main() -> None:
+    os.makedirs("data", exist_ok=True)
+    output_file = os.path.join("data", "mock_market_data.csv")
+    with open(output_file, "w", newline="", encoding="utf-8") as csvfile:
+        writer = csv.DictWriter(
+            csvfile,
+            fieldnames=[
+                "asin",
+                "title",
+                "price",
+                "rating",
+                "reviews",
+                "bsr",
+                "link",
+                "source",
+                "score",
+                "estimated",
+            ],
+        )
+        writer.writeheader()
+        writer.writerows(mock_products)
+    print(f"Mock market data saved to {output_file}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `generate_mock_market_data.py` to build demo CSV
- update `data/mock_market_data.csv` with realistic sample products

## Testing
- `python -m py_compile generate_mock_market_data.py`
- `python generate_mock_market_data.py`

------
https://chatgpt.com/codex/tasks/task_e_684aca5d74f483269657bd5d3313288b