### PR TITLE
Add profitability estimation script

### DIFF
--- a/profitability_estimation.py
+++ b/profitability_estimation.py
@@ -1,0 +1,116 @@
+import os
+import csv
+import re
+
+INPUT_CSV = os.path.join("data", "market_analysis_results.csv")
+SUPPLIER_CSV = os.path.join("data", "supplier_data.csv")
+OUTPUT_CSV = os.path.join("data", "profitability_estimation_results.csv")
+SHIPPING_COST = 2.50
+
+
+def parse_float(value):
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    match = re.search(r"\d+\.\d+|\d+", str(value))
+    return float(match.group()) if match else None
+
+
+def load_supplier_costs(path: str) -> dict:
+    costs = {}
+    if not os.path.exists(path):
+        return costs
+    with open(path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            asin = (row.get("asin") or "").strip()
+            cost = parse_float(row.get("cost"))
+            if asin and cost is not None:
+                costs[asin] = round(cost, 2)
+    return costs
+
+
+def estimate_profit(rows, supplier_costs):
+    results = []
+    for row in rows:
+        price = parse_float(row.get("price"))
+        if price is None:
+            continue
+        asin = row.get("asin") or ""
+        cost = supplier_costs.get(asin, round(price * 0.3, 2))
+        fba_fees = round(price * 0.15 + 3.0, 2)
+        profit = round(price - cost - SHIPPING_COST - fba_fees, 2)
+        total_cost = cost + SHIPPING_COST + fba_fees
+        roi = round(profit / total_cost, 2) if total_cost else 0.0
+        results.append(
+            {
+                "asin": asin,
+                "title": row.get("title", ""),
+                "price": round(price, 2),
+                "cost": cost,
+                "fba_fees": fba_fees,
+                "shipping": SHIPPING_COST,
+                "profit": profit,
+                "roi": roi,
+                "score": row.get("score", ""),
+            }
+        )
+    return results
+
+
+def load_market_data(path: str):
+    if not os.path.exists(path):
+        print(f"Input file '{path}' not found")
+        return []
+    with open(path, newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def save_results(rows, path: str):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        fieldnames = [
+            "asin",
+            "title",
+            "price",
+            "cost",
+            "fba_fees",
+            "shipping",
+            "profit",
+            "roi",
+            "score",
+        ]
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def print_top_products(rows, count=5):
+    rows = sorted(rows, key=lambda x: x["roi"], reverse=True)[:count]
+    header = f"{'ASIN':12} | {'Price':>6} | {'Cost':>6} | {'Profit':>7} | {'ROI':>5}"
+    print(header)
+    print("-" * len(header))
+    for r in rows:
+        print(
+            f"{r['asin']:12} | "
+            f"${r['price']:>6.2f} | "
+            f"${r['cost']:>6.2f} | "
+            f"${r['profit']:>7.2f} | "
+            f"{r['roi']:>5.2f}"
+        )
+
+
+def main():
+    market_data = load_market_data(INPUT_CSV)
+    if not market_data:
+        return
+    supplier_costs = load_supplier_costs(SUPPLIER_CSV)
+    results = estimate_profit(market_data, supplier_costs)
+    save_results(results, OUTPUT_CSV)
+    print_top_products(results, 5)
+    print(f"Results saved to {OUTPUT_CSV}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `profitability_estimation.py` for estimating costs and ROI
- mock supplier costs if `supplier_data.csv` is missing

## Testing
- `python -m py_compile profitability_estimation.py`
- `python profitability_estimation.py` *(with sample data)*

------
https://chatgpt.com/codex/tasks/task_e_685272334830832685ccb50fe74bcc87