### PR TITLE
Add script for generating supplier messages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
-# Copy this file to .env and fill in your SerpAPI key
-SERPAPI_API_KEY=your_api_key_here
+# Copy this file to .env and fill in your API keys
+SERPAPI_API_KEY=your_serpapi_key_here
+# OpenAI key used by generate_supplier_messages.py
+OPENAI_API_KEY=
 # Optional Keepa API key if you prefer to store it in the environment
 KEEPA_API_KEY=

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains a simple script to discover potential Amazon FBA produc
 ## Setup
 1. Install dependencies:
    ```bash
-   pip install python-dotenv google-search-results
+   pip install python-dotenv google-search-results openai
    ```
    The SerpAPI client is imported in the code as `from serpapi import GoogleSearch`.
    If you previously installed the wrong package, you can remove it with:
@@ -51,3 +51,13 @@ python market_analysis.py
 If you want to experiment without valid API keys, run `prepare_mock_data.py`.
 It creates `data/mock_market_data.csv` with sample products and skips creation
 if the file already exists or API credentials are detected.
+
+## Supplier Quote Messages
+The `generate_supplier_messages.py` script sends each product in
+`data/supplier_contact_requests.json` to the OpenAI Chat API and saves the
+resulting emails to `data/supplier_messages.json`. Set your OpenAI key in `.env`
+as `OPENAI_API_KEY` before running:
+
+```bash
+python generate_supplier_messages.py
+```

--- a/generate_supplier_messages.py
+++ b/generate_supplier_messages.py
@@ -1,0 +1,96 @@
+"""Generate supplier quote request messages using OpenAI's Chat API."""
+
+import json
+import os
+from typing import List, Dict
+
+import openai
+from dotenv import load_dotenv
+
+
+INPUT_JSON = os.path.join("data", "supplier_contact_requests.json")
+OUTPUT_JSON = os.path.join("data", "supplier_messages.json")
+
+
+def load_requests(path: str) -> List[Dict[str, object]]:
+    """Return list of contact requests from JSON file."""
+    if not os.path.exists(path):
+        print(f"Input file '{path}' not found.")
+        return []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as exc:
+        print(f"Error reading {path}: {exc}")
+        return []
+
+
+def save_messages(rows: List[Dict[str, str]], path: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(rows, f, indent=2)
+    except Exception as exc:
+        print(f"Error writing {path}: {exc}")
+
+
+def generate_message(units: int, title: str) -> str:
+    """Return a polite supplier message for the given product."""
+
+    system = {
+        "role": "system",
+        "content": "You are an AI assistant helping a seller request quotes from suppliers.",
+    }
+    user = {
+        "role": "user",
+        "content": (
+            "Please write a professional message to a supplier requesting a quote "
+            f"for {units} units of '{title}'. Mention that we are evaluating "
+            "suppliers for potential bulk orders and would like price and "
+            "shipping details for this order quantity."
+        ),
+    }
+
+    try:
+        response = openai.ChatCompletion.create(model="gpt-4", messages=[system, user])
+    except Exception as exc:
+        raise RuntimeError(f"OpenAI API error: {exc}") from exc
+
+    content = response["choices"][0]["message"]["content"]
+    return content.strip()
+
+
+def main() -> None:
+    load_dotenv()
+    key = os.getenv("OPENAI_API_KEY")
+    if not key:
+        raise SystemExit("OPENAI_API_KEY not set in environment")
+
+    openai.api_key = key
+
+    requests = load_requests(INPUT_JSON)
+    if not requests:
+        return
+
+    messages: List[Dict[str, str]] = []
+    for req in requests:
+        asin = req.get("asin", "")
+        title = req.get("title", "")
+        units = req.get("units") or 0
+        try:
+            msg = generate_message(int(units), title)
+        except Exception as exc:
+            print(f"Failed to generate message for ASIN {asin}: {exc}")
+            continue
+        messages.append({"asin": asin, "title": title, "message": msg})
+
+    if messages:
+        save_messages(messages, OUTPUT_JSON)
+        print(f"Generated {len(messages)} messages.")
+    else:
+        print("No messages were generated.")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add `generate_supplier_messages.py` for creating OpenAI-generated supplier messages
- extend `.env.example` with `OPENAI_API_KEY`
- document new dependencies and usage in README

## Testing
- `python -m py_compile generate_supplier_messages.py`
- `python generate_supplier_messages.py` *(fails: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6852b9d035a48326aef1637dc5d014e2