### PR TITLE
Add supplier contact management and pricing simulator

### DIFF
--- a/pricing_simulator.py
+++ b/pricing_simulator.py
@@ -1,12 +1,15 @@
-import os
+"""Simulate pricing strategies based on profitability and demand data."""
+
 import csv
+import os
 import re
 from typing import Dict, List, Optional
 
-INVENTORY_CSV = os.path.join("data", "inventory_management_results.csv")
 PROFIT_CSV = os.path.join("data", "profitability_estimation_results.csv")
-OUTPUT_CSV = os.path.join("data", "pricing_simulation_results.csv")
+DEMAND_CSV = os.path.join("data", "demand_forecast_results.csv")
 
+
+# Parsing helpers ---------------------------------------------------------
 
 def parse_float(val: Optional[str]) -> Optional[float]:
     if val is None:
@@ -26,6 +29,8 @@ def parse_int(val: Optional[str]) -> Optional[int]:
     return int(m.group()) if m else None
 
 
+# Loading ----------------------------------------------------------------
+
 def load_rows(path: str) -> List[Dict[str, str]]:
     if not os.path.exists(path):
         return []
@@ -33,18 +38,20 @@ def load_rows(path: str) -> List[Dict[str, str]]:
         return list(csv.DictReader(f))
 
 
-def join_data(inv_rows: List[Dict[str, str]], profit_rows: List[Dict[str, str]]) -> List[Dict[str, object]]:
-    inv_map = {r.get("asin", ""): r for r in inv_rows}
+def join_data(profit_rows: List[Dict[str, str]], demand_rows: List[Dict[str, str]]) -> List[Dict[str, object]]:
+    demand_map = {r.get("asin"): r for r in demand_rows}
     combined: List[Dict[str, object]] = []
     for p in profit_rows:
         asin = p.get("asin") or ""
-        inv = inv_map.get(asin)
-        if not inv:
+        d = demand_map.get(asin)
+        if not d:
             continue
         price = parse_float(p.get("price"))
         cost = parse_float(p.get("cost"))
-        stock = parse_int(inv.get("recommended_stock"))
-        if price is None or cost is None or stock is None:
+        shipping = parse_float(p.get("shipping")) or 0.0
+        fba_fees = parse_float(p.get("fba_fees")) or 0.0
+        sales = parse_int(d.get("est_monthly_sales")) or 0
+        if price is None or cost is None:
             continue
         combined.append(
             {
@@ -52,59 +59,55 @@ def join_data(inv_rows: List[Dict[str, str]], profit_rows: List[Dict[str, str]])
                 "title": p.get("title", ""),
                 "price": price,
                 "cost": cost,
-                "stock": stock,
+                "shipping": shipping,
+                "fba_fees": fba_fees,
+                "base_sales": sales,
             }
         )
     return combined
 
 
+# Simulation --------------------------------------------------------------
+
 def simulate(rows: List[Dict[str, object]]) -> List[Dict[str, object]]:
     results: List[Dict[str, object]] = []
     for row in rows:
-        price = row["price"]
+        base_price = row["price"]
         cost = row["cost"]
-        stock = row["stock"]
-        for pct in (-0.2, -0.1, 0.0, 0.1, 0.2):
-            new_price = round(price * (1 + pct), 2)
-            profit_unit = round(new_price - cost, 2)
-            roi = round(profit_unit / cost, 2) if cost else 0.0
-            proj_profit = round(profit_unit * stock, 2)
+        shipping = row["shipping"]
+        base_fees = row["fba_fees"]
+        base_sales = row["base_sales"]
+        for step in range(0, 6):  # 0% to 50% in 10% increments
+            pct = step * 0.1
+            new_price = round(base_price * (1 + pct), 2)
+            sales_factor = max(0.0, 1 - 1.5 * pct)  # +10% price => -15% sales
+            est_sales = int(round(base_sales * sales_factor))
+            fba_fees = new_price * 0.15 + 3.0 if base_fees else 0.0
+            profit_unit = new_price - cost - shipping - fba_fees
+            roi = (
+                round(profit_unit / (cost + shipping + fba_fees), 2)
+                if (cost + shipping + fba_fees)
+                else 0.0
+            )
+            total_profit = round(profit_unit * est_sales, 2)
             results.append(
                 {
                     "asin": row["asin"],
-                    "original_price": price,
-                    "simulated_price": new_price,
-                    "profit_per_unit": profit_unit,
+                    "original_price": base_price,
+                    "new_price": new_price,
+                    "estimated_sales": est_sales,
+                    "new_profit": total_profit,
                     "roi": roi,
-                    "projected_profit": proj_profit,
                 }
             )
     return results
 
 
-def save_results(rows: List[Dict[str, object]]):
-    os.makedirs(os.path.dirname(OUTPUT_CSV), exist_ok=True)
-    with open(OUTPUT_CSV, "w", newline="", encoding="utf-8") as f:
-        writer = csv.DictWriter(
-            f,
-            fieldnames=[
-                "asin",
-                "original_price",
-                "simulated_price",
-                "profit_per_unit",
-                "roi",
-                "projected_profit",
-            ],
-        )
-        writer.writeheader()
-        for r in rows:
-            writer.writerow(r)
-
+# Printing ----------------------------------------------------------------
 
 def print_table(rows: List[Dict[str, object]]):
     header = (
-        f"{'ASIN':12} | {'Orig Price':>10} | {'Sim Price':>9} | "
-        f"{'Profit/U':>8} | {'ROI':>5} | {'Proj Profit':>12}"
+        f"{'ASIN':12} | {'Orig Price':>10} | {'New Price':>9} | {'Sales':>6} | {'Profit':>10} | {'ROI':>5}"
     )
     print(header)
     print("-" * len(header))
@@ -112,30 +115,30 @@ def print_table(rows: List[Dict[str, object]]):
         print(
             f"{r['asin']:12} | "
             f"${r['original_price']:>10.2f} | "
-            f"${r['simulated_price']:>9.2f} | "
-            f"${r['profit_per_unit']:>8.2f} | "
-            f"{r['roi']:>5.2f} | "
-            f"${r['projected_profit']:>12.2f}"
+            f"${r['new_price']:>9.2f} | "
+            f"{r['estimated_sales']:>6} | "
+            f"${r['new_profit']:>10.2f} | "
+            f"{r['roi']:>5.2f}"
         )
 
 
+# Main --------------------------------------------------------------------
+
 def main() -> None:
-    inv_rows = load_rows(INVENTORY_CSV)
     prof_rows = load_rows(PROFIT_CSV)
-    if not inv_rows:
-        print(f"Input file '{INVENTORY_CSV}' not found. Exiting.")
-        return
+    demand_rows = load_rows(DEMAND_CSV)
     if not prof_rows:
         print(f"Input file '{PROFIT_CSV}' not found. Exiting.")
         return
-    combined = join_data(inv_rows, prof_rows)
+    if not demand_rows:
+        print(f"Input file '{DEMAND_CSV}' not found. Exiting.")
+        return
+    combined = join_data(prof_rows, demand_rows)
     if not combined:
         print("No matching products found.")
         return
     sims = simulate(combined)
     print_table(sims)
-    save_results(sims)
-    print(f"Results saved to {OUTPUT_CSV}")
 
 
 if __name__ == "__main__":

--- a/supplier_contact_sender.py
+++ b/supplier_contact_sender.py
@@ -1,0 +1,132 @@
+"""Send supplier contact emails and log interactions."""
+
+import csv
+import os
+import smtplib
+from datetime import datetime
+from email.message import EmailMessage
+from typing import Dict, List
+
+from dotenv import load_dotenv
+
+CONTACT_DIR = os.path.join("data", "supplier_contacts")
+LOG_CSV = os.path.join("data", "supplier_contact_log.csv")
+
+load_dotenv()
+
+SMTP_SERVER = os.getenv("SMTP_SERVER")
+SMTP_PORT = int(os.getenv("SMTP_PORT", "587"))
+SMTP_USER = os.getenv("SMTP_USER")
+SMTP_PASSWORD = os.getenv("SMTP_PASSWORD")
+EMAIL_FROM = os.getenv("EMAIL_FROM", "noreply@example.com")
+EMAIL_TO = os.getenv("EMAIL_TO", "supplier@example.com")
+TEST_MODE = os.getenv("TEST_MODE", "1") == "1" or not all(
+    [SMTP_SERVER, SMTP_USER, SMTP_PASSWORD]
+)
+
+
+def list_contact_files() -> List[str]:
+    if not os.path.isdir(CONTACT_DIR):
+        return []
+    return [
+        os.path.join(CONTACT_DIR, f)
+        for f in os.listdir(CONTACT_DIR)
+        if f.lower().endswith(".txt")
+    ]
+
+
+def parse_contact_file(path: str) -> Dict[str, str]:
+    asin = ""
+    title = ""
+    with open(path, "r", encoding="utf-8") as f:
+        lines = f.read().splitlines()
+    for line in lines[:5]:  # look for asin and title in first lines
+        if line.lower().startswith("asin:"):
+            asin = line.split(":", 1)[1].strip()
+        if line.lower().startswith("title:"):
+            title = line.split(":", 1)[1].strip()
+    if not asin:
+        base = os.path.basename(path)
+        asin = base.split("_")[0]
+    if not title:
+        title = os.path.basename(path).rsplit(".", 1)[0]
+    message = "\n".join(lines)
+    return {"asin": asin, "title": title, "message": message}
+
+
+def load_log() -> List[Dict[str, str]]:
+    if not os.path.exists(LOG_CSV):
+        return []
+    with open(LOG_CSV, newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def save_log(rows: List[Dict[str, str]]) -> None:
+    os.makedirs(os.path.dirname(LOG_CSV), exist_ok=True)
+    with open(LOG_CSV, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "ASIN",
+                "Title",
+                "Date Sent",
+                "Email Sent To",
+                "Status",
+                "Response Date",
+                "Notes",
+            ],
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def send_email(subject: str, body: str) -> None:
+    if TEST_MODE:
+        print(f"[TEST MODE] Would send email to {EMAIL_TO} with subject '{subject}'")
+        return
+    msg = EmailMessage()
+    msg["From"] = EMAIL_FROM
+    msg["To"] = EMAIL_TO
+    msg["Subject"] = subject
+    msg.set_content(body)
+    try:
+        with smtplib.SMTP(SMTP_SERVER, SMTP_PORT) as smtp:
+            smtp.starttls()
+            smtp.login(SMTP_USER, SMTP_PASSWORD)
+            smtp.send_message(msg)
+    except Exception as exc:
+        print(f"Error sending email: {exc}")
+
+
+def process_files() -> None:
+    files = list_contact_files()
+    if not files:
+        print(f"No contact files found in '{CONTACT_DIR}'.")
+        return
+    log_rows = load_log()
+    existing_asins = {r["ASIN"] for r in log_rows}
+    for path in files:
+        data = parse_contact_file(path)
+        asin = data["asin"]
+        if asin in existing_asins:
+            continue
+        title = data["title"]
+        send_email(f"Supplier inquiry for {asin}", data["message"])
+        now = datetime.utcnow().strftime("%Y-%m-%d")
+        log_rows.append(
+            {
+                "ASIN": asin,
+                "Title": title,
+                "Date Sent": now,
+                "Email Sent To": EMAIL_TO,
+                "Status": "sent" if not TEST_MODE else "pending",
+                "Response Date": "",
+                "Notes": "",
+            }
+        )
+    save_log(log_rows)
+    print(f"Logged {len(log_rows)} contacts to {LOG_CSV}")
+
+
+if __name__ == "__main__":
+    process_files()

--- a/supplier_contact_tracker.py
+++ b/supplier_contact_tracker.py
@@ -1,0 +1,90 @@
+"""Manage supplier contact log via CLI."""
+
+import argparse
+import csv
+import os
+from typing import Dict, List
+
+LOG_CSV = os.path.join("data", "supplier_contact_log.csv")
+
+
+def load_log() -> List[Dict[str, str]]:
+    if not os.path.exists(LOG_CSV):
+        return []
+    with open(LOG_CSV, newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def save_log(rows: List[Dict[str, str]]) -> None:
+    os.makedirs(os.path.dirname(LOG_CSV), exist_ok=True)
+    with open(LOG_CSV, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "ASIN",
+                "Title",
+                "Date Sent",
+                "Email Sent To",
+                "Status",
+                "Response Date",
+                "Notes",
+            ],
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def list_contacts(rows: List[Dict[str, str]]):
+    if not rows:
+        print("No contacts logged.")
+        return
+    header = (
+        f"{'ASIN':12} | {'Title':30} | {'Status':10} | {'Date Sent':10} | {'Resp Date':10}"
+    )
+    print(header)
+    print("-" * len(header))
+    for r in rows:
+        print(
+            f"{r['ASIN']:12} | {(r['Title'] or '')[:30]:30} | {r['Status']:10} | "
+            f"{r['Date Sent']:10} | {r['Response Date']:10}"
+        )
+
+
+def update_contact(asin: str, status: str, response_date: str, notes: str) -> None:
+    rows = load_log()
+    for r in rows:
+        if r["ASIN"] == asin:
+            r["Status"] = status
+            if response_date:
+                r["Response Date"] = response_date
+            if notes:
+                r["Notes"] = notes
+            save_log(rows)
+            print(f"Updated {asin}.")
+            return
+    print(f"ASIN {asin} not found in log.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Track supplier contacts")
+    sub = parser.add_subparsers(dest="cmd")
+
+    sub.add_parser("list", help="List logged contacts")
+
+    up = sub.add_parser("update", help="Update a contact")
+    up.add_argument("asin", help="ASIN to update")
+    up.add_argument("--status", choices=["pending", "sent", "responded", "rejected"], required=True)
+    up.add_argument("--response-date", default="")
+    up.add_argument("--notes", default="")
+
+    args = parser.parse_args()
+    rows = load_log()
+
+    if args.cmd == "update":
+        update_contact(args.asin, args.status, args.response_date, args.notes)
+    else:
+        list_contacts(rows)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `supplier_contact_sender.py` to send emails and log contact attempts
- add `supplier_contact_tracker.py` CLI to update contact status
- refactor `pricing_simulator.py` to simulate price strategies using demand and profitability data

## Testing
- `python -m py_compile supplier_contact_sender.py supplier_contact_tracker.py pricing_simulator.py`
- `python pricing_simulator.py --help` *(fails: missing input CSVs)*
- `pip install python-dotenv` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6852bd39a0948326b64d6546ffe6d64a