### PR TITLE
Modernize pricing simulator with OpenAI v1 API

### DIFF
--- a/pricing_simulator.py
+++ b/pricing_simulator.py
@@ -1,129 +1,126 @@
-"""Simulate how selling price changes impact ROI and total profit."""
+"""ChatGPT-based pricing optimization for FBA products."""
 
 import csv
 import os
 import re
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
+
+from dotenv import load_dotenv
+from openai import OpenAI
 
 INPUT_CSV = os.path.join("data", "profitability_estimation_results.csv")
 OUTPUT_CSV = os.path.join("data", "pricing_simulation_results.csv")
-VARIATIONS = [-0.2, -0.1, 0.0, 0.1, 0.2]
-DEFAULT_SALES = 100  # units used if no sales info available
 
 
-# Parsing helpers ---------------------------------------------------------
-
-def parse_float(val: Optional[str]) -> Optional[float]:
-    if val is None:
+def parse_float(value: Optional[str]) -> Optional[float]:
+    """Return float extracted from a string or None."""
+    if value is None:
         return None
-    if isinstance(val, (int, float)):
-        return float(val)
-    m = re.search(r"\d+\.\d+|\d+", str(val))
-    return float(m.group()) if m else None
+    if isinstance(value, (int, float)):
+        return float(value)
+    match = re.search(r"\d+\.\d+|\d+", str(value))
+    return float(match.group()) if match else None
 
 
-def parse_int(val: Optional[str]) -> Optional[int]:
-    if val is None:
-        return None
-    if isinstance(val, int):
-        return val
-    m = re.search(r"\d+", str(val))
-    return int(m.group()) if m else None
-
-
-# Loading ----------------------------------------------------------------
-
-def load_rows(path: str) -> List[Dict[str, str]]:
+def load_profitable_products(path: str) -> List[Dict[str, str]]:
+    """Load rows with ROI >= 0.5 from the CSV file."""
     if not os.path.exists(path):
+        print(f"Input file '{path}' not found. Run profitability_estimation.py first.")
         return []
+    rows: List[Dict[str, str]] = []
     with open(path, newline="", encoding="utf-8") as f:
-        return list(csv.DictReader(f))
+        reader = csv.DictReader(f)
+        for row in reader:
+            roi = parse_float(row.get("roi"))
+            if roi is not None and roi >= 0.5:
+                rows.append(row)
+    if not rows:
+        print("No products with ROI >= 0.5 found.")
+    return rows
 
 
-# Simulation --------------------------------------------------------------
-
-def simulate(rows: List[Dict[str, str]]) -> List[Dict[str, object]]:
-    results: List[Dict[str, object]] = []
-    for row in rows:
-        price = parse_float(row.get("price"))
-        cost = parse_float(row.get("cost")) or 0.0
-        shipping = parse_float(row.get("shipping")) or 0.0
-        base_sales = parse_int(row.get("est_monthly_sales")) or DEFAULT_SALES
-        if price is None or cost is None:
-            continue
-        for pct in VARIATIONS:
-            new_price = round(price * (1 + pct), 2)
-            fba_fees = round(new_price * 0.15 + 3.0, 2)
-            margin = new_price - cost - shipping - fba_fees
-            total_cost = cost + shipping + fba_fees
-            roi = round(margin / total_cost, 2) if total_cost else 0.0
-            total_profit = round(margin * base_sales, 2)
-            results.append(
-                {
-                    "asin": row.get("asin", ""),
-                    "title": row.get("title", ""),
-                    "variation": f"{pct:+.0%}",
-                    "new_price": new_price,
-                    "margin_per_unit": round(margin, 2),
-                    "roi": roi,
-                    "total_profit": total_profit,
-                }
-            )
-    return results
-
-
-# Saving -----------------------------------------------------------------
-
-def save_results(rows: List[Dict[str, object]], path: str) -> None:
+def save_results(rows: List[Dict[str, str]], path: str) -> None:
+    """Save pricing suggestions to CSV."""
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, "w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(
             f,
-            fieldnames=[
-                "asin",
-                "title",
-                "variation",
-                "new_price",
-                "margin_per_unit",
-                "roi",
-                "total_profit",
-            ],
+            fieldnames=["ASIN", "Title", "Recommended Price Strategy", "Notes"],
         )
         writer.writeheader()
         writer.writerows(rows)
 
 
-# Printing ----------------------------------------------------------------
+def ask_question(client: OpenAI, messages: List[Dict[str, str]], question: str) -> str:
+    """Send a question to ChatGPT and return the answer."""
+    messages.append({"role": "user", "content": question})
+    response = client.chat.completions.create(model="gpt-4", messages=messages)
+    answer = response.choices[0].message.content.strip()
+    messages.append({"role": "assistant", "content": answer})
+    return answer
 
-def print_table(rows: List[Dict[str, object]]) -> None:
-    header = (
-        f"{'ASIN':12} | {'Var':>5} | {'Price':>8} | {'Margin':>8} | {'ROI':>5} | {'Tot Profit':>11}"
+
+def analyze_product(client: OpenAI, asin: str, title: str) -> Tuple[str, str]:
+    """Run a short pricing conversation for a product."""
+    messages: List[Dict[str, str]] = [
+        {"role": "system", "content": "You are a pricing strategy expert for FBA products"}
+    ]
+
+    q1 = "\u00bfQu\u00e9 rango de precios maximizar\u00eda ventas sin comprometer margen?"
+    q2 = "\u00bfUn aumento de precio del 10% afectar\u00eda significativamente la demanda?"
+    q3 = (
+        "\u00bfQu\u00e9 estrategia de precios podr\u00eda aplicarse para lanzamiento "
+        "(descuento, bundle, etc.)?"
     )
-    print(header)
-    print("-" * len(header))
-    for r in rows:
-        print(
-            f"{r['asin']:12} | {r['variation']:>5} | ${r['new_price']:>8.2f} | "
-            f"${r['margin_per_unit']:>8.2f} | {r['roi']:>5.2f} | ${r['total_profit']:>11.2f}"
-        )
 
+    print(f"\n### ASIN {asin} - {title}")
+    a1 = ask_question(client, messages, f"Producto: {title}. {q1}")
+    print(f"Q1: {q1}\nA1: {a1}")
+    a2 = ask_question(client, messages, q2)
+    print(f"Q2: {q2}\nA2: {a2}")
+    a3 = ask_question(client, messages, q3)
+    print(f"Q3: {q3}\nA3: {a3}\n")
 
-# Main --------------------------------------------------------------------
+    notes = f"{a1} | {a2}"
+    return a3, notes
+
 
 def main() -> None:
-    rows = load_rows(INPUT_CSV)
-    if not rows:
-        print(
-            f"Input file '{INPUT_CSV}' not found. Run profitability_estimation.py first."
+    load_dotenv()
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        print("OPENAI_API_KEY not found in environment or .env file.")
+        return
+
+    client = OpenAI(api_key=api_key)
+
+    products = load_profitable_products(INPUT_CSV)
+    if not products:
+        return
+
+    results: List[Dict[str, str]] = []
+    for row in products:
+        asin = row.get("asin", "")
+        title = row.get("title", "")
+        try:
+            strategy, notes = analyze_product(client, asin, title)
+        except Exception as exc:  # pragma: no cover - network
+            print(f"Failed to get pricing advice for ASIN {asin}: {exc}")
+            continue
+        results.append(
+            {
+                "ASIN": asin,
+                "Title": title,
+                "Recommended Price Strategy": strategy,
+                "Notes": notes,
+            }
         )
-        return
-    sims = simulate(rows)
-    if not sims:
-        print("No valid rows found for simulation.")
-        return
-    print_table(sims)
-    save_results(sims, OUTPUT_CSV)
-    print(f"Results saved to {OUTPUT_CSV}")
+
+    if results:
+        save_results(results, OUTPUT_CSV)
+        print(f"Results saved to {OUTPUT_CSV}")
+    else:
+        print("No results to save.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- rewrite `pricing_simulator.py` to work with `openai>=1.0`
- load API key from `.env`
- filter profitable products (ROI >= 0.5)
- ask ChatGPT pricing questions for each product
- save recommendations to `data/pricing_simulation_results.csv`

## Testing
- `python -m py_compile pricing_simulator.py`

------
https://chatgpt.com/codex/tasks/task_e_6852cc5a6fe08326a00710e6698140fe