### PR TITLE
Enhance supplier message generator with templates and logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,7 @@
 SERPAPI_API_KEY=your_serpapi_key_here
 # OpenAI key used by generate_supplier_messages.py
 OPENAI_API_KEY=
+# Optional model name for OpenAI requests
+OPENAI_MODEL=gpt-4
 # Optional Keepa API key if you prefer to store it in the environment
 KEEPA_API_KEY=

--- a/template.txt
+++ b/template.txt
@@ -1,0 +1,2 @@
+Write a {tone} message in {language} to the supplier about the product titled '{title}' (ASIN {asin}). Ask for minimum order quantity (MOQ), unit price, catalogue of similar items and delivery time.
+


### PR DESCRIPTION
## Summary
- allow configurable OpenAI model via `.env`
- read prompt text from new `template.txt`
- support tone and language options
- log API and file errors to `supplier_errors.log`
- report success/failure count at the end
- update example environment file with `OPENAI_MODEL`

## Testing
- `python -m py_compile supplier_contact_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_6852da78f7048326a9b53be8d1fc6d84