### PR TITLE
Add template and logging features to supplier generator

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,7 @@
 SERPAPI_API_KEY=your_serpapi_key_here
 # OpenAI key used by generate_supplier_messages.py
 OPENAI_API_KEY=
+# Optional OpenAI model to use
+OPENAI_MODEL=gpt-4
 # Optional Keepa API key if you prefer to store it in the environment
 KEEPA_API_KEY=

--- a/supplier_contact_generator.py
+++ b/supplier_contact_generator.py
@@ -2,17 +2,60 @@
 
 from __future__ import annotations
 
+import argparse
 import csv
 import os
+import time
 from typing import Dict, List
 
 from dotenv import load_dotenv
 from openai import OpenAI
 
 
+def parse_args() -> argparse.Namespace:
+    """Return command line arguments."""
+
+    parser = argparse.ArgumentParser(
+        description="Generate supplier inquiry messages using OpenAI"
+    )
+    parser.add_argument("--lang", default="en", help="language code for template")
+    parser.add_argument("--tone", default="formal", help="tone for template")
+    return parser.parse_args()
+
+
+def load_template(lang: str, tone: str) -> str:
+    """Load template file for the given language and tone."""
+
+    names = [f"template_{lang}_{tone}.txt", "template.txt"]
+    for name in names:
+        if os.path.exists(name):
+            with open(name, "r", encoding="utf-8") as f:
+                text = f.read()
+            if "{title}" not in text or "{asin}" not in text:
+                raise ValueError(
+                    f"Template '{name}' missing '{{title}}' or '{{asin}}' placeholder"
+                )
+            return text
+    raise FileNotFoundError(
+        "Template file not found (searched: " + ", ".join(names) + ")"
+    )
+
+
+def log_error(asin: str, title: str, error: str) -> None:
+    """Append an error entry to ``supplier_errors.log``."""
+
+    ts = time.strftime("%Y-%m-%d %H:%M:%S")
+    try:
+        with open(ERROR_LOG, "a", encoding="utf-8") as f:
+            f.write(f"{ts}\t{asin}\t{title}\t{error}\n")
+    except Exception:
+        pass
+
+
 INPUT_CSV = os.path.join("data", "supplier_selection_results.csv")
 OUTPUT_DIR = "supplier_messages"
-MODEL = "gpt-4"
+ERROR_LOG = "supplier_errors.log"
+DEFAULT_MODEL = "gpt-4"
 SYSTEM_PROMPT = "You are an expert FBA sourcing agent helping contact suppliers."
 
 
@@ -48,32 +91,31 @@ def load_products(path: str) -> List[Dict[str, str]]:
     return rows
 
 
-def generate_message(client: OpenAI, title: str) -> str:
-    """Generate a polite supplier message for the given product title."""
+def generate_message(
+    client: OpenAI, model: str, template: str, asin: str, title: str
+) -> str:
+    """Generate a polite supplier message for the given product."""
 
     messages = [
         {"role": "system", "content": SYSTEM_PROMPT},
-        {
-            "role": "user",
-            "content": (
-                "Write a short message to the supplier about the product titled "
-                f"'{title}'. Ask for minimum order quantity (MOQ), unit price, "
-                "catalogue of similar items and delivery time."
-            ),
-        },
+        {"role": "user", "content": template.format(title=title, asin=asin)},
     ]
 
-    resp = client.chat.completions.create(model=MODEL, messages=messages)
+    resp = client.chat.completions.create(model=model, messages=messages)
     return resp.choices[0].message.content.strip()
 
 
 def main() -> None:
+    args = parse_args()
+
     load_dotenv()
 
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         print("OPENAI_API_KEY not found in .env")
         return
+
+    model = os.getenv("OPENAI_MODEL", DEFAULT_MODEL)
 
     client = OpenAI(api_key=api_key)
 
@@ -92,13 +134,32 @@ def main() -> None:
 
     os.makedirs(OUTPUT_DIR, exist_ok=True)
 
+    try:
+        template = load_template(args.lang, args.tone)
+        template_err: str | None = None
+    except Exception as exc:
+        template = ""
+        template_err = str(exc)
+        print(template_err)
+
+    success = 0
+    failures = 0
+
     for prod in products:
         asin = prod["asin"]
         title = prod["title"]
+
+        if template_err:
+            log_error(asin, title, template_err)
+            failures += 1
+            continue
+
         try:
-            message = generate_message(client, title)
+            message = generate_message(client, model, template, asin, title)
         except Exception as exc:  # pragma: no cover - network
             print(f"Failed to generate message for {asin}: {exc}")
+            log_error(asin, title, str(exc))
+            failures += 1
             continue
 
         out_path = os.path.join(OUTPUT_DIR, f"{asin}.txt")
@@ -106,8 +167,13 @@ def main() -> None:
             with open(out_path, "w", encoding="utf-8") as f:
                 f.write(f"ASIN: {asin}\nTitle: {title}\n\n{message}\n")
             print(f"Saved message for {asin} in {out_path}")
+            success += 1
         except Exception as exc:
             print(f"Error saving message for {asin}: {exc}")
+            log_error(asin, title, str(exc))
+            failures += 1
+
+    print(f"Messages generated: {success}. Failures: {failures}.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow language and tone arguments in supplier message generator
- look up template files and format prompts with ASIN and title
- read OpenAI model from `.env`
- log generation failures to `supplier_errors.log` and show final stats
- document OPENAI_MODEL in `.env.example`

## Testing
- `python -m py_compile supplier_contact_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_6852db1b47ac83269d4938e4b5688f9f