### PR TITLE
Improve supplier contact generator

### DIFF
--- a/template.txt
+++ b/template.txt
@@ -1,2 +1,2 @@
-Write a {tone} message in {language} to the supplier about the product titled '{title}' (ASIN {asin}). Ask for minimum order quantity (MOQ), unit price, catalogue of similar items and delivery time.
+Write a professional message in English to the supplier about the product titled '{title}' (ASIN {asin}). Ask for minimum order quantity (MOQ), unit price, catalogue of similar items and delivery time.
 


### PR DESCRIPTION
## Summary
- use OpenAI client with model from `.env`
- load template per product and log errors
- remove tone/language options and enforce English messages
- log failures in `supplier_errors.log`
- summarize attempts at the end
- update default `template.txt`

## Testing
- `python -m py_compile supplier_contact_generator.py`
- `python supplier_contact_generator.py --help` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6852df0d1ad88326a6839573fb6ffb22