### PR TITLE
Add fallback supplier message template

### DIFF
--- a/supplier_contact_generator.py
+++ b/supplier_contact_generator.py
@@ -3,7 +3,9 @@
 This script reads products from ``data/supplier_selection_results.csv`` and
 creates one text file per ASIN inside ``supplier_messages/``. The prompt sent to
 OpenAI is loaded from ``template.txt`` which should contain ``{title}`` and
-``{asin}`` placeholders. Messages are generated in English only.
+``{asin}`` placeholders. Messages are generated in English only. If the OpenAI
+API or the requested model is unavailable, a default English template is used
+instead.
 """
 
 from __future__ import annotations
@@ -23,6 +25,19 @@ TEMPLATE_FILE = "template.txt"
 ERROR_LOG = "supplier_errors.log"
 
 SYSTEM_PROMPT = "You are an expert FBA sourcing agent helping contact suppliers."
+
+# Default English fallback template used when OpenAI is unavailable
+FALLBACK_TEMPLATE = (
+    "Subject: Product Inquiry - {product_title}\n\n"
+    "Dear Sir or Madam,\n\n"
+    "I am interested in sourcing the product \"{product_title}\". "
+    "Could you please provide the minimum order quantity (MOQ), price per unit, "
+    "and estimated lead time? I would also appreciate your catalogue of similar products.\n\n"
+    "Best regards,  \n"
+    "Carlos Ruiz  \n"
+    "sourcing@example.com  \n"
+    "Spain"
+)
 
 
 def parse_units(value: str | None) -> int:
@@ -66,6 +81,12 @@ def load_template(path: str) -> str:
         return f.read()
 
 
+def fallback_message(title: str) -> str:
+    """Return the default supplier message using the product title."""
+
+    return FALLBACK_TEMPLATE.format(product_title=title)
+
+
 def generate_message(
     client: OpenAI,
     asin: str,
@@ -105,13 +126,17 @@ def main() -> None:
 
     load_dotenv()
 
-    api_key = os.getenv("OPENAI_API_KEY")
+    api_key = os.getenv("OPENAI_API_KEY") or os.getenv("openai_key")
     model = os.getenv("OPENAI_MODEL", "gpt-4")
-    if not api_key:
-        print("OPENAI_API_KEY not found in .env")
-        return
+    model_access = os.getenv("OPENAI_MODEL_ACCESS", "true").lower() not in (
+        "0",
+        "false",
+        "no",
+    )
 
-    client = OpenAI(api_key=api_key)
+    use_openai = bool(api_key) and model_access
+
+    client = OpenAI(api_key=api_key) if use_openai else None
 
     try:
         products = load_products(INPUT_CSV)
@@ -143,13 +168,17 @@ def main() -> None:
             failures += 1
             continue
 
-        try:
-            message = generate_message(client, asin, title, template, model)
-        except Exception as exc:  # pragma: no cover - network
-            print(f"Failed to generate message for {asin}: {exc}")
-            log_error(asin, title, exc)
-            failures += 1
-            continue
+        if use_openai:
+            try:
+                message = generate_message(client, asin, title, template, model)
+            except Exception as exc:  # pragma: no cover - network
+                print(f"Failed to generate message for {asin}: {exc}")
+                log_error(asin, title, exc)
+                message = fallback_message(title)
+                print(f"Used fallback template for ASIN {asin}")
+        else:
+            message = fallback_message(title)
+            print(f"Used fallback template for ASIN {asin}")
 
         out_path = os.path.join(OUTPUT_DIR, f"{asin}.txt")
         try:


### PR DESCRIPTION
## Summary
- support fallback template in `supplier_contact_generator.py`
- generate fallback messages when OpenAI key or model access is missing
- log fallback use per ASIN

## Testing
- `python -m py_compile supplier_contact_generator.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6852e26440dc8326bc2c39686bef5346