### PR TITLE
Add negotiation agent email automation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,8 @@ OPENAI_API_KEY=
 OPENAI_MODEL=gpt-4
 # Optional Keepa API key if you prefer to store it in the environment
 KEEPA_API_KEY=
+# Email credentials for negotiation_agent.py
+EMAIL_ADDRESS=
+EMAIL_PASSWORD=
+# Set to True to automatically send replies
+AUTO_REPLY=False

--- a/README.md
+++ b/README.md
@@ -61,3 +61,12 @@ as `OPENAI_API_KEY` before running:
 ```bash
 python generate_supplier_messages.py
 ```
+
+## Email Negotiation Agent
+The `negotiation_agent.py` script connects to a Gmail inbox, summarizes unread supplier emails and optionally sends replies with GPT‑4. Configure `EMAIL_ADDRESS`, `EMAIL_PASSWORD` and `OPENAI_API_KEY` in your `.env` file. Enable automatic sending by setting `AUTO_REPLY=True`.
+
+Run it manually with:
+```bash
+python negotiation_agent.py
+```
+It is also executed automatically by `fba_agent.py` when credentials are present.

--- a/fba_agent.py
+++ b/fba_agent.py
@@ -29,6 +29,7 @@ OUTPUTS: Dict[str, str] = {
     "supplier_contact_generator": "supplier_messages",
     "pricing_simulator": os.path.join(DATA_DIR, "pricing_suggestions.csv"),
     "inventory_management": os.path.join(DATA_DIR, "inventory_management_results.csv"),
+    "negotiation_agent": os.path.join("logs", "email_negotiation_log.txt"),
 }
 
 
@@ -251,6 +252,8 @@ def main() -> None:
         "OpenAI": bool(openai_key),
         OPENAI_MODEL: openai_model if openai_key else False,
     }
+    negotiation_exists = os.path.exists("negotiation_agent.py")
+    email_ok = bool(os.getenv("EMAIL_ADDRESS") and os.getenv("EMAIL_PASSWORD"))
     print_service_status(services)
     ensure_mock_data(services)
 
@@ -279,6 +282,13 @@ def main() -> None:
         ("supplier_contact_generator", ["supplier_contact_generator.py"], None, [OUTPUTS["supplier_contact_generator"]], services["OpenAI"] and services[OPENAI_MODEL]),
         ("pricing_simulator", ["pricing_simulator.py"], None, [OUTPUTS["pricing_simulator"]], services["OpenAI"] and services[OPENAI_MODEL]),
         ("inventory_management", ["inventory_management.py"], None, [OUTPUTS["inventory_management"]], True),
+        (
+            "negotiation_agent",
+            ["negotiation_agent.py"],
+            None,
+            [OUTPUTS["negotiation_agent"]],
+            negotiation_exists and services["OpenAI"] and services[OPENAI_MODEL] and email_ok,
+        ),
     ]
 
     step_names = [s[0] for s in steps]

--- a/negotiation_agent.py
+++ b/negotiation_agent.py
@@ -1,0 +1,242 @@
+"""Automated email negotiation agent for supplier communications."""
+
+from __future__ import annotations
+
+import email
+import imaplib
+import json
+import os
+import smtplib
+from email.header import decode_header
+from email.message import EmailMessage
+from email.utils import parseaddr
+from typing import List, Tuple
+
+from dotenv import load_dotenv
+
+try:
+    from openai import OpenAI
+except Exception:  # pragma: no cover - library might be missing
+    OpenAI = None  # type: ignore
+
+IMAP_SERVER = "imap.gmail.com"
+SMTP_SERVER = "smtp.gmail.com"
+SMTP_PORT = 587
+
+KEYWORDS = [
+    "quotation",
+    "moq",
+    "pricing",
+    "price",
+    "shipping",
+    "sample",
+    "payment",
+    "terms",
+]
+
+LOG_PATH = os.path.join("logs", "email_negotiation_log.txt")
+
+
+def decode(value: str | bytes | None) -> str:
+    """Return decoded string value."""
+
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        try:
+            return value.decode()
+        except Exception:
+            return value.decode("utf-8", "ignore")
+    return str(value)
+
+
+def parse_email(msg: email.message.Message) -> Tuple[str, str, str]:
+    """Extract ``(subject, sender, body)`` from an email message."""
+
+    raw_subject = msg.get("Subject", "")
+    parts = decode_header(raw_subject)
+    subject = "".join(decode(p[0]) for p in parts)
+    sender = parseaddr(msg.get("From", ""))[1]
+
+    body = ""
+    if msg.is_multipart():
+        for part in msg.walk():
+            if part.get_content_type() == "text/plain" and not part.get("Content-Disposition"):
+                body_bytes = part.get_payload(decode=True)
+                body += decode(body_bytes)
+                break
+    else:
+        body = decode(msg.get_payload(decode=True))
+
+    return subject, sender, body.strip()
+
+
+def analyse_email(
+    client: OpenAI,
+    model: str,
+    sender: str,
+    subject: str,
+    body: str,
+) -> Tuple[str, bool, str]:
+    """Return ``(summary, reply_needed, reply_text)`` using OpenAI."""
+
+    system = (
+        "You are an assistant for an Amazon FBA seller. "
+        "Summarize the supplier email and indicate if a reply is required. "
+        "If a reply is required, draft a short professional response. "
+        "Respond in JSON with keys 'summary', 'reply_needed' and 'reply'."
+    )
+    user = f"From: {sender}\nSubject: {subject}\n\n{body}"
+    try:
+        resp = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "system", "content": system}, {"role": "user", "content": user}],
+        )
+    except Exception as exc:  # pragma: no cover - network
+        raise RuntimeError(f"OpenAI API error: {exc}") from exc
+
+    content = resp.choices[0].message.content.strip()
+    try:
+        data = json.loads(content)
+        summary = data.get("summary", "")
+        reply_needed = bool(data.get("reply_needed"))
+        reply_text = data.get("reply", "")
+    except json.JSONDecodeError:
+        summary = content
+        reply_needed = False
+        reply_text = ""
+    return summary, reply_needed, reply_text
+
+
+def send_reply(
+    email_addr: str,
+    password: str,
+    recipient: str,
+    subject: str,
+    body: str,
+) -> None:
+    """Send an email reply via SMTP."""
+
+    msg = EmailMessage()
+    msg["From"] = email_addr
+    msg["To"] = recipient
+    msg["Subject"] = f"Re: {subject}"
+    msg.set_content(body)
+
+    with smtplib.SMTP(SMTP_SERVER, SMTP_PORT) as smtp:
+        smtp.starttls()
+        smtp.login(email_addr, password)
+        smtp.send_message(msg)
+
+
+def log_entry(
+    sender: str,
+    subject: str,
+    body: str,
+    summary: str,
+    reply_needed: bool,
+    reply: str,
+) -> None:
+    """Append an entry to the log file."""
+
+    os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
+    with open(LOG_PATH, "a", encoding="utf-8") as f:
+        f.write(f"FROM: {sender}\n")
+        f.write(f"SUBJECT: {subject}\n")
+        f.write("BODY:\n" + body + "\n")
+        f.write("SUMMARY: " + summary + "\n")
+        f.write(f"REPLY_NEEDED: {reply_needed}\n")
+        if reply:
+            f.write("REPLY:\n" + reply + "\n")
+        f.write("-" * 40 + "\n")
+
+
+def main() -> None:
+    load_dotenv()
+
+    email_addr = os.getenv("EMAIL_ADDRESS")
+    password = os.getenv("EMAIL_PASSWORD")
+    auto_reply = os.getenv("AUTO_REPLY", "false").lower() in {"1", "true", "yes"}
+    api_key = os.getenv("OPENAI_API_KEY")
+    model = os.getenv("OPENAI_MODEL", "gpt-4")
+
+    if not email_addr or not password:
+        print("EMAIL_ADDRESS or EMAIL_PASSWORD not configured.")
+        return
+
+    openai_ok = bool(api_key and OpenAI)
+    client = None
+    if openai_ok:
+        try:
+            client = OpenAI(api_key=api_key)
+        except Exception as exc:  # pragma: no cover - network
+            print(f"OpenAI initialization failed: {exc}")
+            openai_ok = False
+
+    try:
+        imap = imaplib.IMAP4_SSL(IMAP_SERVER)
+        imap.login(email_addr, password)
+        imap.select("INBOX")
+    except Exception as exc:
+        print(f"Failed to connect to IMAP: {exc}")
+        return
+
+    status, data = imap.search(None, "UNSEEN")
+    if status != "OK":
+        print("Failed to search mailbox.")
+        imap.logout()
+        return
+
+    ids = data[0].split()
+    processed: List[Tuple[str, str]] = []
+    replies: List[str] = []
+
+    for num in ids:
+        status, fetched = imap.fetch(num, "(RFC822)")
+        if status != "OK" or not fetched:
+            continue
+        msg = email.message_from_bytes(fetched[0][1])
+        subject, sender, body = parse_email(msg)
+        text = (subject + "\n" + body).lower()
+        if not any(k in text for k in KEYWORDS):
+            continue
+
+        summary = body[:120]
+        reply_needed = False
+        reply_text = ""
+
+        if openai_ok and client:
+            try:
+                summary, reply_needed, reply_text = analyse_email(
+                    client, model, sender, subject, body
+                )
+            except Exception as exc:  # pragma: no cover - network
+                print(f"OpenAI error for email from {sender}: {exc}")
+                openai_ok = False
+
+        log_entry(sender, subject, body, summary, reply_needed, reply_text)
+        processed.append((sender, subject))
+
+        if reply_needed and reply_text:
+            if auto_reply and openai_ok:
+                try:
+                    send_reply(email_addr, password, sender, subject, reply_text)
+                    replies.append(sender)
+                except Exception as exc:  # pragma: no cover - network
+                    print(f"Failed to send reply to {sender}: {exc}")
+            else:
+                print(f"Draft reply for {sender}:\n{reply_text}\n")
+
+    imap.logout()
+
+    print("Processed emails:")
+    for sender, subj in processed:
+        sent = sender in replies
+        status_str = "reply sent" if sent else "logged"
+        print(f" - {sender} | {subj} ({status_str})")
+    if not processed:
+        print("No new supplier emails found.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `negotiation_agent.py` to read supplier emails via IMAP, summarize them with GPT-4 and optionally send replies
- integrate the negotiation agent into `fba_agent.py` pipeline when credentials and OpenAI are available
- document the new script and environment variables
- extend `.env.example` with email credentials

## Testing
- `python -m py_compile negotiation_agent.py fba_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_6852e79cbed0832692c5cdc50e1adfe0