### PR TITLE
Add order placement step to pipeline

### DIFF
--- a/fba_agent.py
+++ b/fba_agent.py
@@ -47,6 +47,7 @@ OUTPUTS: Dict[str, str] = {
     "inventory_management": os.path.join(DATA_DIR, "inventory_management_results.csv"),
     "negotiation_agent": os.path.join("logs", "email_negotiation_log.txt"),
     "email_manager": "email_logs",
+    "order_placement_agent": os.path.join("logs", "order_confirmation_log.txt"),
 }
 
 
@@ -338,6 +339,13 @@ def main() -> None:
             [OUTPUTS["email_manager"]],
             email_ok,
         ),
+        (
+            "order_placement_agent",
+            ["order_placement_agent.py"],
+            None,
+            [OUTPUTS["order_placement_agent"]],
+            True,
+        ),
     ]
 
     step_names = [s[0] for s in steps]
@@ -376,6 +384,15 @@ def main() -> None:
             log(f"RESULT {name} skipped 0s missing_input")
             statuses[name] = "skipped"
             continue
+        if name == "order_placement_agent":
+            msgs_dir = OUTPUTS["supplier_contact_generator"]
+            if not os.path.exists(OUTPUTS["supplier_selection"]) or not os.path.isdir(msgs_dir) or not os.listdir(msgs_dir):
+                print(
+                    f"{Fore.YELLOW}! {name} skipped due to missing supplier selection results or messages{Style.RESET_ALL}"
+                )
+                log(f"RESULT {name} skipped 0s missing_input")
+                statuses[name] = "skipped"
+                continue
         if ask_reuse(name, paths, auto=args.auto, force=args.reuse or statuses.get(name) == "reused"):
             statuses[name] = "reused"
             generated.extend(p for p in paths if os.path.exists(p))

--- a/order_placement_agent.py
+++ b/order_placement_agent.py
@@ -15,6 +15,11 @@ from importlib.util import find_spec
 from typing import Dict, List, Tuple
 import argparse
 
+try:
+    from dotenv import load_dotenv
+except Exception:  # pragma: no cover - optional dependency
+    load_dotenv = lambda: None  # type: ignore
+
 REQUIRED_PACKAGES = {
     "yagmail": "yagmail",
     "dotenv": "python-dotenv",
@@ -64,6 +69,7 @@ MESSAGES_DIR = "supplier_messages"
 LOG_CSV = os.path.join("data", "order_placement_log.csv")
 TMP_DIR = os.path.join("data", "edited_messages")
 CONFIG_JSON = "config.json"
+CONFIRM_LOG = os.path.join("logs", "order_confirmation_log.txt")
 
 
 # ---------------------------------------------------------------------------
@@ -111,8 +117,6 @@ def extract_email(text: str) -> str | None:
 
 
 def load_credentials() -> Tuple[str | None, str | None, str, int]:
-    from dotenv import load_dotenv
-
     load_dotenv()
     config: Dict[str, str] = {}
     if os.path.exists(CONFIG_JSON):
@@ -366,6 +370,9 @@ def main(argv: List[str] | None = None) -> None:
         smtp_server=args.smtp_server,
         smtp_port=args.smtp_port,
     )
+    os.makedirs(os.path.dirname(CONFIRM_LOG), exist_ok=True)
+    with open(CONFIRM_LOG, "a", encoding="utf-8") as f:
+        f.write(f"run_completed {datetime.utcnow().isoformat()}\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add fallback dotenv import and output log in `order_placement_agent.py`
- create `order_confirmation_log.txt` output path
- integrate order placement step into `fba_agent.py`
- skip step when prerequisite files are missing
- ensure tests compile and import new step

## Testing
- `python test_all.py --verbose`

------
https://chatgpt.com/codex/tasks/task_e_6855396e59c4832696bcb5e2dae98ed6