### PR TITLE
Add pipeline reset feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,3 +180,17 @@ This command runs the pipeline without user prompts, fixes any broken code, and 
 
 - If Git is not configured or an error occurs, a warning will be shown but the process continues.
 - You are encouraged to review changes using GitHub or `git diff` before deploying to production.
+
+## 🔄 Resetting the Pipeline
+
+To clean up the project and reset the pipeline, run:
+
+```bash
+python reset_pipeline.py
+```
+
+You can also do this automatically by adding the --reset flag to `fba_agent.py`:
+
+```bash
+python fba_agent.py --auto --reset
+```

--- a/fba_agent.py
+++ b/fba_agent.py
@@ -78,6 +78,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="automatically fix validation errors and commit the changes",
     )
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        help="clear previous outputs and logs before running",
+    )
     return parser.parse_args()
 
 
@@ -356,6 +361,12 @@ def load_last_statuses() -> Dict[str, str]:
 def main() -> None:
     colorama_init()
     args = parse_args()
+    if args.reset:
+        try:
+            import reset_pipeline
+            reset_pipeline.reset()
+        except Exception as exc:  # pragma: no cover - reset failure
+            print(f"Reset failed: {exc}")
 
     log("RUN START")
     services, serp, keepa, openai_key, openai_model = detect_services()

--- a/reset_pipeline.py
+++ b/reset_pipeline.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Reset all generated pipeline outputs and logs."""
+
+import os
+import glob
+import shutil
+
+DATA_DIR = "data"
+MSG_DIR = "supplier_messages"
+EMAIL_DIR = "email_logs"
+LOGS_DIR = "logs"
+LOG_FILE = "log.txt"
+
+
+def safe_remove(path: str) -> None:
+    """Remove a file if it exists."""
+    if os.path.isfile(path) or os.path.islink(path):
+        try:
+            os.remove(path)
+            print(f"Deleted {path}")
+        except Exception as exc:  # pragma: no cover - permissions
+            print(f"Could not delete {path}: {exc}")
+
+
+def safe_rmtree(path: str) -> None:
+    """Remove a directory and its contents if it exists."""
+    if os.path.isdir(path):
+        try:
+            shutil.rmtree(path)
+            print(f"Removed {path}/")
+        except Exception as exc:  # pragma: no cover - permissions
+            print(f"Could not remove {path}: {exc}")
+
+
+def reset() -> None:
+    """Delete pipeline outputs and logs."""
+    pattern = os.path.join(DATA_DIR, "*.csv")
+    for fname in glob.glob(pattern):
+        if os.path.basename(fname).startswith("mock_"):
+            continue
+        safe_remove(fname)
+
+    for folder in (MSG_DIR, EMAIL_DIR, LOGS_DIR):
+        safe_rmtree(folder)
+
+    safe_remove(LOG_FILE)
+
+
+def main() -> None:
+    reset()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `reset_pipeline.py` to clear outputs and logs
- expose `--reset` option in `fba_agent.py`
- document pipeline reset usage in README

## Testing
- `python mock_data_generator.py`
- `python reset_pipeline.py`
- `python fba_agent.py --auto --reset` *(fails: prompts for API keys)*
- `python validate_all.py` *(fails: cannot install pandas)*

------
https://chatgpt.com/codex/tasks/task_e_685c27a4eb8483269e557c6512e29061