### PR TITLE
Improve pipeline usability

### DIFF
--- a/product_discovery.py
+++ b/product_discovery.py
@@ -14,6 +14,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument('--debug', action='store_true', help='Enable debug output')
     parser.add_argument('--verbose', action='store_true', help='Enable detailed console output')
     parser.add_argument('--max-products', type=int, default=10, help='Maximum number of products to process (if applicable)')
+    parser.add_argument('--budget', type=float, help='Total startup budget in USD')
     return parser.parse_args()
 
 
@@ -288,7 +289,9 @@ def print_report(products: List[Dict[str, object]]):
 
 def main() -> None:
     try:
-        if args.auto:
+        if args.budget is not None:
+            budget = args.budget
+        elif args.auto:
             budget = 1000.0
         else:
             budget = float(input("Enter your total startup budget in USD: "))


### PR DESCRIPTION
## Summary
- accept `--budget` for product_discovery to avoid double prompt
- modularize fba pipeline steps
- add plan mode and input validation
- log user choices and budget
- show better failure messages

## Testing
- `python test_all.py` *(fails: help/auto for some scripts)*

------
https://chatgpt.com/codex/tasks/task_e_685e6217e9ec8326b0542be2437bba0b