### PR TITLE
Add KDP cover and manuscript generators

### DIFF
--- a/kdp_content_generator.py
+++ b/kdp_content_generator.py
@@ -1,0 +1,90 @@
+import os
+import re
+import argparse
+from typing import Optional, List
+
+try:
+    from openai import OpenAI
+except Exception:  # pragma: no cover - openai optional
+    OpenAI = None  # type: ignore
+
+
+def slugify(text: str) -> str:
+    return re.sub(r'[^a-z0-9]+', '_', text.lower()).strip('_')
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate KDP book content")
+    parser.add_argument("--book_type", choices=["low-content", "text-content"], required=True)
+    parser.add_argument("--title", required=True, help="Book title")
+    parser.add_argument("--genre", required=True, help="Book genre")
+    parser.add_argument("--chapters", type=int, default=5, help="Number of chapters/pages")
+    parser.add_argument("--tone", help="Writing tone")
+    parser.add_argument("--audience", help="Target audience")
+    parser.add_argument("--mock", action="store_true", help="Use mock content")
+    parser.add_argument("--auto", action="store_true", help="Run without prompts")
+    return parser.parse_args()
+
+
+def generate_text_content(client: Optional[OpenAI], args: argparse.Namespace) -> str:
+    chapters: List[str] = []
+    for i in range(1, args.chapters + 1):
+        if not client:
+            chapters.append(f"Chapter {i}\nLorem ipsum dolor sit amet...")
+            continue
+        prompt = (
+            f"Write chapter {i} of a {args.genre} book titled '{args.title}'."
+        )
+        if args.tone:
+            prompt += f" Tone: {args.tone}."
+        if args.audience:
+            prompt += f" Audience: {args.audience}."
+        try:
+            resp = client.chat.completions.create(
+                model="gpt-4",
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.7,
+            )
+            chapters.append(resp.choices[0].message.content.strip())
+        except Exception:
+            chapters.append(f"Chapter {i}\n(Content unavailable)")
+    return "\n\n".join(chapters)
+
+
+def generate_low_content(args: argparse.Namespace) -> str:
+    pages = [f"Page {i}" for i in range(1, args.chapters + 1)]
+    return "\n".join(pages)
+
+
+def main() -> None:
+    args = parse_args()
+    os.makedirs("manuscripts", exist_ok=True)
+
+    if args.book_type == "text-content" and args.chapters <= 1:
+        print("text-content books require at least 2 chapters")
+        return
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    client = None
+    if not args.mock and api_key and OpenAI:
+        try:
+            client = OpenAI(api_key=api_key)
+        except Exception as exc:  # pragma: no cover - network
+            print(f"OpenAI initialization failed: {exc}")
+            client = None
+    elif not args.mock:
+        print("OpenAI API not available, using mock content.")
+
+    if args.book_type == "low-content":
+        content = generate_low_content(args)
+    else:
+        content = generate_text_content(client, args)
+
+    filename = os.path.join("manuscripts", f"{slugify(args.title)}_manuscript.txt")
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(content)
+    print(f"Manuscript saved to {filename}")
+
+
+if __name__ == "__main__":
+    main()

--- a/kdp_cover_generator.py
+++ b/kdp_cover_generator.py
@@ -1,0 +1,77 @@
+import os
+import re
+import argparse
+import base64
+from typing import Optional
+
+try:
+    from openai import OpenAI
+except Exception:  # pragma: no cover - openai optional
+    OpenAI = None  # type: ignore
+
+PLACEHOLDER_IMAGE = base64.b64decode(
+    b'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z/CfHgAHggJ/P9n3WQAAAABJRU5ErkJggg=='
+)
+
+
+def slugify(text: str) -> str:
+    return re.sub(r'[^a-z0-9]+', '_', text.lower()).strip('_')
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate a KDP book cover")
+    parser.add_argument("--title", required=True, help="Book title")
+    parser.add_argument("--subtitle", help="Optional subtitle")
+    parser.add_argument("--author", required=True, help="Author name")
+    parser.add_argument("--genre", required=True, help="Book genre")
+    parser.add_argument("--style", default="minimalist", help="Cover style")
+    parser.add_argument("--size", default="6x9", help="Book size")
+    parser.add_argument("--mock", action="store_true", help="Use mock image")
+    parser.add_argument("--auto", action="store_true", help="Run without prompts")
+    return parser.parse_args()
+
+
+def generate_image(prompt: str, client: Optional[OpenAI]) -> bytes:
+    if not client:
+        return PLACEHOLDER_IMAGE
+    try:
+        resp = client.images.generate(model="dall-e-3", prompt=prompt, n=1, size="1024x1024")
+        url = resp.data[0].url
+        if not url:
+            return PLACEHOLDER_IMAGE
+        import requests
+        return requests.get(url, timeout=10).content
+    except Exception:
+        return PLACEHOLDER_IMAGE
+
+
+def main() -> None:
+    args = parse_args()
+    os.makedirs("covers", exist_ok=True)
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    client = None
+    if not args.mock and api_key and OpenAI:
+        try:
+            client = OpenAI(api_key=api_key)
+        except Exception as exc:  # pragma: no cover - network
+            print(f"OpenAI initialization failed: {exc}")
+            client = None
+    elif not args.mock:
+        print("OpenAI API not available, using mock image.")
+
+    prompt = f"{args.style} {args.genre} book cover titled '{args.title}'"
+    if args.subtitle:
+        prompt += f" subtitle '{args.subtitle}'"
+    prompt += f" by {args.author}"
+
+    image_data = generate_image(prompt, client)
+
+    filename = os.path.join("covers", f"{slugify(args.title)}_cover.png")
+    with open(filename, "wb") as f:
+        f.write(image_data)
+    print(f"Cover saved to {filename}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `kdp_cover_generator.py` for automated cover creation
- add `kdp_content_generator.py` for generating KDP manuscripts

## Testing
- `python kdp_cover_generator.py --help`
- `python kdp_content_generator.py --help`
- `python kdp_cover_generator.py --title test --author Jane --genre romance --mock`
- `python kdp_content_generator.py --book_type low-content --title Diary --genre self-help --chapters 3 --mock`
- `python test_all.py`
- `python validate_all.py` *(fails: Could not install pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68879e9a4e9083268528bba73074f671