### PR TITLE
Add KDP-focused Streamlit UI

### DIFF
--- a/kdp_ui.py
+++ b/kdp_ui.py
@@ -1,0 +1,47 @@
+import streamlit as st
+import pandas as pd
+import subprocess
+import os
+
+st.sidebar.title("📚 Panel de navegación")
+section = st.sidebar.radio("Selecciona una sección", ["KDP", "FBA", "Análisis", "Ventas"], index=0)
+
+if section == "KDP":
+    st.title("📘 Kindle Direct Publishing (KDP)")
+
+    if os.path.exists("niches_found.csv"):
+        niches_df = pd.read_csv("niches_found.csv")
+        niches = niches_df["niche"].dropna().unique().tolist()
+
+        st.subheader("🔍 Análisis de Competencia")
+
+        if len(niches) < 5:
+            st.info("Menos de 5 nichos encontrados. Analizando todos automáticamente...")
+            summary_rows = []
+
+            for niche in niches:
+                st.write(f"📊 Analizando: **{niche}**...")
+                subprocess.run(["python", "kdp_competition.py", "--niche", niche, "--mock"], check=True)
+                result_df = pd.read_csv("competitor_analysis.csv")
+                avg_row = result_df.tail(1)
+                avg_row.insert(0, "niche", niche)
+                summary_rows.append(avg_row)
+
+            summary_df = pd.concat(summary_rows, ignore_index=True)
+            st.subheader("📈 Resumen de Nichos")
+            st.dataframe(summary_df[["niche", "price", "reviews", "bsr", "keyword_density"]].rename(columns={
+                "price": "avg_price",
+                "reviews": "avg_reviews",
+                "bsr": "avg_bsr",
+                "keyword_density": "avg_keyword_density"
+            }))
+
+        else:
+            selected_niche = st.selectbox("Selecciona un nicho para analizar:", niches)
+            if st.button("Analizar competencia"):
+                subprocess.run(["python", "kdp_competition.py", "--niche", selected_niche, "--mock"], check=True)
+                result_df = pd.read_csv("competitor_analysis.csv")
+                st.subheader(f"📄 Resultados para: {selected_niche}")
+                st.dataframe(result_df)
+    else:
+        st.warning("No se encontró el archivo niches_found.csv. Por favor, lanza primero el descubrimiento de nichos.")


### PR DESCRIPTION
## Summary
- create new `kdp_ui.py` Streamlit script
- default KDP tab selected, auto-run analysis for less than five niches or allow manual selection otherwise

## Testing
- `python test_all.py`
- `python validate_all.py` *(fails: Could not install pandas)*

------
https://chatgpt.com/codex/tasks/task_e_688b5543e0c48326b6df7c0716894702