### PR TITLE
fix: guard niche table against missing columns

### DIFF
--- a/kdp_ui.py
+++ b/kdp_ui.py
@@ -59,12 +59,14 @@ def kdp_section() -> None:
         st.markdown(f"### 📊 Nichos Detectados para '{selected_keyword}'")
         st.markdown("Fuente: *Selenium scraping sobre Amazon.es autocomplete*")
 
-        # Validar columnas esperadas antes de mostrar tabla
+        # Validar columnas antes de intentar mostrarlas
         expected_cols = ["niche", "competition", "avg_bsr", "saturation", "search_volume"]
-        missing_cols = [col for col in expected_cols if col not in df.columns]
-
-        if missing_cols:
-            st.error(f"⚠️ El archivo `{niches_file}` no contiene las columnas esperadas: {missing_cols}")
+        if not all(col in df.columns for col in expected_cols):
+            st.error(f"❌ El archivo `{niches_file}` no contiene todas las columnas esperadas.")
+            st.code(
+                f"Columnas encontradas: {list(df.columns)}\n"
+                f"Faltantes: {[col for col in expected_cols if col not in df.columns]}"
+            )
             st.stop()
 
         st.dataframe(df[expected_cols])


### PR DESCRIPTION
## Summary
- improve KDP UI niche display by validating required columns before rendering
- show an error with column details and stop the app when CSV is incomplete

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68909bf9cfa4832695e18ef44aa36e52